### PR TITLE
feat: #28 - 통계 화면 리스트 UI 구성

### DIFF
--- a/PodoIt/Models/StatsModel.swift
+++ b/PodoIt/Models/StatsModel.swift
@@ -11,13 +11,16 @@ import SwiftData
 // 카테고리별 시간 모델
 @Model
 final class CategoryTimeModel {
+  var icon: String
   var category: String
   var time: Int
 
   init(
+    icon: String,
     category: String,
     time: Int
   ) {
+    self.icon = icon
     self.category = category
     self.time = time
   }
@@ -25,7 +28,8 @@ final class CategoryTimeModel {
 
 // Stats 모델
 @Model
-final class StatsModel {
+final class StatsModel: Hashable {
+  var statsID: UUID
   var date: Date
   var dayTotalTime: Int
   var monthTotalTime: Int
@@ -39,10 +43,12 @@ final class StatsModel {
   var monthCategoryTimes: [CategoryTimeModel] = []
 
   init(
+    statsID: UUID = UUID(),
     date: Date,
     dayTotalTime: Int,
     monthTotalTime: Int
   ) {
+    self.statsID = statsID
     self.date = date
     self.dayTotalTime = dayTotalTime
     self.monthTotalTime = monthTotalTime

--- a/PodoIt/Scenes/Stats/View/StatsCollectionViewCell.swift
+++ b/PodoIt/Scenes/Stats/View/StatsCollectionViewCell.swift
@@ -1,0 +1,88 @@
+//
+//  StatsCollectionViewCell.swift
+//  PodoIt
+//
+//  Created by 김이든 on 8/26/25.
+//
+
+import UIKit
+
+final class StatsCollectionViewCell: UICollectionViewCell {
+  static let reuseIdentifier = "StatsCollectionViewCell"
+
+  // MARK: - Metrics
+
+  private enum Metrics {
+    static let emojiFont: CGFloat = 18
+    static let hStackSpacing: CGFloat = 8
+  }
+
+  // MARK: - Properties
+
+  private let iconLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: Metrics.emojiFont)
+    $0.textAlignment = .left
+  }
+
+  private let titleLabel = UILabel().then {
+    $0.font = Typography.font(for: .bodyMd(weight: .medium))
+    $0.textColor = .gray500
+    $0.textAlignment = .left
+  }
+
+  private lazy var hStack = UIStackView(arrangedSubviews: [iconLabel, titleLabel]).then {
+    $0.axis = .horizontal
+    $0.spacing = Metrics.hStackSpacing
+  }
+
+  private let timeLabel = UILabel().then {
+    $0.font = Typography.font(for: .bodyMd(weight: .medium))
+    $0.textColor = .gray700
+    $0.textAlignment = .right
+  }
+
+  // MARK: - Init
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupUI()
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - SetupUI
+
+  private func setupUI() {
+    [hStack, timeLabel].forEach {
+      contentView.addSubview($0)
+    }
+
+    hStack.snp.makeConstraints {
+      $0.leading.equalToSuperview()
+      $0.centerY.equalToSuperview()
+    }
+
+    timeLabel.snp.makeConstraints {
+      $0.trailing.equalToSuperview()
+      $0.centerY.equalToSuperview()
+    }
+  }
+
+  // MARK: - Configure
+
+  func configure(icon: String, title: String, stats: String) {
+    iconLabel.text = icon
+    titleLabel.text = title
+    timeLabel.text = stats
+  }
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    iconLabel.text = nil
+    titleLabel.text = nil
+    timeLabel.text = nil
+  }
+}

--- a/PodoIt/Scenes/Stats/View/StatsCustomSegmentedControl.swift
+++ b/PodoIt/Scenes/Stats/View/StatsCustomSegmentedControl.swift
@@ -100,8 +100,6 @@ final class StatsCustomSegmentedControl: UIView {
   private var segments: [SegmentChipView] = []
   private let highlightLayer = SegmentHighlightLayer()
 
-  private var didSetupInitialSelection = false
-
   private(set) var selectedIndex: Int = 0
   let tapIndexRelay = PublishRelay<Int>()
 
@@ -122,12 +120,9 @@ final class StatsCustomSegmentedControl: UIView {
   override func layoutSubviews() {
     super.layoutSubviews()
     layer.cornerRadius = bounds.height / 2
-    // highlight Layer 초기 1회 설정 체크
-    guard !didSetupInitialSelection, !segments.isEmpty else { return }
     // stackView가 layout 계산 완료 후 실행
     stackView.layoutIfNeeded()
     setSelectedIndex(selectedIndex, animated: false)
-    didSetupInitialSelection = true
   }
 
   // StackView 설정

--- a/PodoIt/Scenes/Stats/View/StatsSummaryView.swift
+++ b/PodoIt/Scenes/Stats/View/StatsSummaryView.swift
@@ -12,13 +12,33 @@ import Then
 import UIKit
 
 final class StatsSummaryView: UIView {
-  private let disposeBag = DisposeBag()
+  // 더미데이터
+  struct DummyStatsData: Hashable {
+    let icon: String
+    let title: String
+    let stats: String
+  }
+
+  let dummyStats: [DummyStatsData] = [
+    DummyStatsData(icon: "🔥", title: "공부", stats: "1시간 5분"),
+    DummyStatsData(icon: "💻", title: "개발", stats: "1시간 40분"),
+    DummyStatsData(icon: "🦊", title: "운동", stats: "1시간 1분"),
+    DummyStatsData(icon: "🐶", title: "산책", stats: "55분"),
+    DummyStatsData(icon: "🐤", title: "강의 듣기", stats: "1시간 33분"),
+    DummyStatsData(icon: "🍇", title: "포도 먹기", stats: "5분"),
+  ]
+
+  // MARK: - Metrics
 
   private enum Layout {
     static let horizontalPadding: CGFloat = 20
     static let verticalPadding: CGFloat = 16
     static let summaryPadding: CGFloat = 16
   }
+
+  // MARK: - Properties
+
+  private let disposeBag = DisposeBag()
 
   private let container = PaddedContainerView(horizontal: Layout.horizontalPadding, vertical: Layout.verticalPadding).then {
     $0.backgroundColor = .gray100
@@ -54,23 +74,70 @@ final class StatsSummaryView: UIView {
     $0.attributedText = attributedString
   }
 
-  private lazy var vStack = UIStackView(arrangedSubviews: [segmentedControl, totalTimeLabel]).then {
+  // 컬렉션 뷰
+  private lazy var collectionView: UICollectionView = {
+    // 레이아웃 항목 구성
+    let itemSize = NSCollectionLayoutSize(
+      widthDimension: .fractionalWidth(1.0),
+      heightDimension: .absolute(36) // 셀 높이 고정
+    )
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+    // 그룹 구성
+    let groupSize = NSCollectionLayoutSize(
+      widthDimension: .fractionalWidth(1.0),
+      heightDimension: .estimated(36) // 예상 높이 설정
+    )
+    let group = NSCollectionLayoutGroup.horizontal(
+      layoutSize: groupSize,
+      subitems: [item]
+    )
+
+    // 섹션 구성
+    let section = NSCollectionLayoutSection(group: group)
+
+    // 레이아웃 구성
+    let layout = UICollectionViewCompositionalLayout(section: section)
+    let collectionView = UICollectionView(
+      frame: .zero,
+      collectionViewLayout: layout
+    )
+    collectionView.register(
+      StatsCollectionViewCell.self,
+      forCellWithReuseIdentifier: StatsCollectionViewCell.reuseIdentifier
+    )
+    collectionView.isScrollEnabled = false
+    return collectionView
+  }()
+
+  // 컬렉션 뷰 데이터 소스
+  private lazy var dataSource = makeDataSource(collectionView)
+
+  // 높이를 제약할 변수
+  private var collectionViewHeightConstraint: Constraint?
+
+  private lazy var vStack = UIStackView(arrangedSubviews: [segmentedControl, totalTimeLabel, collectionView]).then {
     $0.axis = .vertical
     $0.distribution = .equalSpacing
     $0.alignment = .center
     $0.spacing = 16
   }
 
+  // MARK: - Init
+
   override init(frame: CGRect) {
     super.init(frame: frame)
     configureUI()
     bind()
+    collectionViewSetup()
   }
 
   @available(*, unavailable)
   required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  // MARK: - ConfigureUI
 
   private func configureUI() {
     setupView()
@@ -95,7 +162,52 @@ final class StatsSummaryView: UIView {
     vStack.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
+
+    collectionView.snp.makeConstraints {
+      // 초기값 0으로 설정, 나중에 계산해서 업데이트
+      collectionViewHeightConstraint = $0.height.equalTo(0).constraint
+      $0.directionalHorizontalEdges.equalToSuperview()
+    }
   }
+
+  // MARK: - CollectionView Setup
+
+  // 컬렉션뷰에 데이터를 적용하는 함수
+  private func collectionViewSetup() {
+    var snapshot = NSDiffableDataSourceSnapshot<Int, DummyStatsData>()
+    snapshot.appendSections([0]) // 단일 섹션
+    snapshot.appendItems(dummyStats) // 더미데이터 적용
+    dataSource.apply(snapshot, animatingDifferences: false)
+    // 셀 높이 계산
+    updateCollectionViewHeight()
+  }
+
+  // DiffableDataSource를 생성하는 함수
+  private func makeDataSource(_ collectionView: UICollectionView) -> UICollectionViewDiffableDataSource<Int, DummyStatsData> {
+    return UICollectionViewDiffableDataSource<Int, DummyStatsData>(
+      collectionView: collectionView
+    ) { collectionView, indexPath, item in
+      guard let cell = collectionView.dequeueReusableCell(
+        withReuseIdentifier: StatsCollectionViewCell.reuseIdentifier,
+        for: indexPath
+      ) as? StatsCollectionViewCell else {
+        return UICollectionViewCell()
+      }
+      cell.configure(icon: item.icon, title: item.title, stats: item.stats)
+      return cell
+    }
+  }
+
+  // 셀 높이 계산 함수
+  private func updateCollectionViewHeight() {
+    let cellHeight: CGFloat = 36 // 셀 높이
+    let totalHeight = CGFloat(dummyStats.count) * cellHeight
+    collectionViewHeightConstraint?.update(offset: totalHeight)
+    // 레이아웃 반영
+    layoutIfNeeded()
+  }
+
+  // MARK: - Bind
 
   private func bind() {
     segmentedControl.tapIndexRelay


### PR DESCRIPTION
## 🔗 관련 이슈

- #28 

## 🔧 PR 요약

- 카테고리별 집중 시간 리스트 CollectionView 구현
- StatsModel 수정
- 탭바 레이아웃 변경마다 갱신되게 수정


## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷

<img width="300" height="700" alt="Simulator Screenshot - iPhone 16e - 2025-08-26 at 17 34 29" src="https://github.com/user-attachments/assets/cbfb74a9-a7f3-4d07-adc2-8c3ec0520185" />