### PR TITLE
feat: #33 - 리뷰 셀에서 앱스토어 페이지 연결 기능 추가

### DIFF
--- a/PodoIt/Scenes/Setting/View/Setting/SettingViewController.swift
+++ b/PodoIt/Scenes/Setting/View/Setting/SettingViewController.swift
@@ -5,12 +5,13 @@
 //  Created by 노가현 on 8/20/25.
 //
 
+import SafariServices
 import SnapKit
 import UIKit
-import SafariServices
 
 final class SettingViewController: UIViewController {
   private let viewModel = SettingViewModel()
+  private let myAppID = 544007664 // 임시 AppID: Youtube
 
   private lazy var tableView = UITableView(frame: .zero, style: .plain).then {
     $0.backgroundColor = .appWhite
@@ -95,6 +96,18 @@ extension SettingViewController: UITableViewDelegate {
       guard let url = URL(string: "https://docs.google.com/forms/d/e/1FAIpQLSc7ek143AR7jBzxrNdbQsHJso4Nv4n_41v0ExHlXwsOHi6gfQ/viewform?usp=header") else { return }
       let safariViewController = SFSafariViewController(url: url)
       present(safariViewController, animated: true, completion: nil)
+    case .review:
+      guard
+        let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id\(myAppID)"), // App Store 앱 직행
+        let webURL = URL(string: "https://apps.apple.com/app/id\(self.myAppID)") // 웹으로 이동(Safari 백업용)
+      else { return }
+
+      // 먼저 App Store 시도 → 실패하면 Safari로 연결
+      UIApplication.shared.open(appStoreURL, options: [:]) { success in
+        if !success {
+          UIApplication.shared.open(webURL)
+        }
+      }
     default: break
     }
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- #33 

## 🔧 PR 요약
- 임시 appID(유튜브)로 App Store 페이지 열기 구현
- App Store 연결 실패 시 Safari 웹 주소로 fallback 처리

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/021b9c94-39dc-418e-adbc-60d216df037e" width="300">

## 📎 기타 참고사항
- 시뮬레이터에 App Store가 없어서 작동하지 않으므로, 실기기로 테스트 완료(제 폰이 베타 버전이라 이든님의 도움을 받았습니다.)
