### PR TITLE
feat: #24 - 목표 집중 시간 Picker UI 구현

### DIFF
--- a/PodoIt/DesignSystem/Font/PodoItFontStyle.swift
+++ b/PodoIt/DesignSystem/Font/PodoItFontStyle.swift
@@ -13,6 +13,7 @@ enum Typography {
     case displayMd(weight: AppFontWeight = .semibold) // 32 / 40
     case headingLg // 18 / 28 Bold
     case headingMd // 16 / 24 Semi
+    case headingXl(weight: AppFontWeight = .semibold) // 20 / 32 Bold or Semi
     case bodyLg(weight: AppFontWeight = .regular) // 16 / 24 Regular or Medium
     case bodyMd(weight: AppFontWeight = .regular) // 14 / 20 Regular or Medium
     case labelLg(weight: AppFontWeight = .regular) // 16 / 24 Regular or Medium
@@ -37,6 +38,8 @@ enum Typography {
       return .init(size: 18, lineHeight: 28, weight: .bold)
     case .headingMd:
       return .init(size: 16, lineHeight: 24, weight: .semibold)
+    case .headingXl(let w):
+      return .init(size: 20, lineHeight: 32, weight: w)
     case .bodyLg(let w):
       return .init(size: 16, lineHeight: 24, weight: w)
     case .bodyMd(let w):

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -283,6 +283,19 @@ final class TimerEditViewController: UIViewController {
 
   // MARK: - Collapsed/Expanded
 
+  // 펼침/접힘에 따라 ValueArea의 배경/모서리를 토글
+  private func updateValueAreaStyle(isCollapsed: Bool) {
+    if isCollapsed {
+      goalValueArea.backgroundColor = .gray100
+      goalValueArea.layer.cornerRadius = Metrics.cornerRadius
+      goalValueArea.clipsToBounds = true
+    } else {
+      goalValueArea.backgroundColor = .clear
+      goalValueArea.layer.cornerRadius = 0
+      goalValueArea.clipsToBounds = false
+    }
+  }
+
   private func updateCollapsedLabelText() {
     // 숫자(마지막 글자에만 kerning 8)
     let number = NSMutableAttributedString(
@@ -308,8 +321,9 @@ final class TimerEditViewController: UIViewController {
     collapsedValueLabel.isHidden = false
 
     minutePickerMinHeightConstraint?.deactivate()
-
     goalContainerHeightConstraint?.update(offset: Metrics.goalContainerHeightCollapsed)
+    updateValueAreaStyle(isCollapsed: true)
+
     let changes = { self.view.layoutIfNeeded() }
     animated ? UIView.animate(withDuration: 0.25, animations: changes) : changes()
   }
@@ -321,8 +335,9 @@ final class TimerEditViewController: UIViewController {
     collapsedValueLabel.isHidden = true
 
     minutePickerMinHeightConstraint?.activate()
-
     goalContainerHeightConstraint?.update(offset: Metrics.goalContainerHeightExpanded)
+    updateValueAreaStyle(isCollapsed: false)
+
     let changes = { self.view.layoutIfNeeded() }
     animated ? UIView.animate(withDuration: 0.28, delay: 0, usingSpringWithDamping: 0.9, initialSpringVelocity: 0.6, options: .curveEaseInOut, animations: changes) : changes()
   }

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -19,12 +19,16 @@ final class TimerEditViewController: UIViewController {
     static let verticalSpacing: CGFloat = 12
     static let buttonHeight: CGFloat = 48
     static let emojiButtonSize: CGFloat = 56
-    static let goalContainerHeightCollapsed: CGFloat = 112
+    static let goalContainerHeightCollapsed: CGFloat = 240
     static let textFieldHeight: CGFloat = 56
     static let textFieldLeftPadding: CGFloat = 16
     static let topOffset: CGFloat = 32
     static let bottomSafeAreaInset: CGFloat = 20
     static let dashedCircleSize: CGFloat = 40
+
+    // Picker
+    static let inlinePickerMinWidth: CGFloat = 90
+    static let pickerRowHeight: CGFloat = 48
   }
 
   // MARK: - UI Components
@@ -86,30 +90,37 @@ final class TimerEditViewController: UIViewController {
     $0.clipsToBounds = true
   }
 
-  // 접힘 UI일 때 중앙에 보이는 숫자/단위 라벨
-  private let collapsedNumberLabel = UILabel().then {
-    $0.attributedText = Typography.attributed(
-      "50",
-      style: .displayMd(weight: .semibold),
-      color: .appBlack
-    )
-    $0.textAlignment = .center
+  // 분 선택 피커
+  private lazy var minutePicker = UIPickerView().then {
+    $0.dataSource = self
+    $0.delegate = self
+    $0.backgroundColor = .clear
   }
 
-  private let collapsedUnitLabel = UILabel().then {
-    $0.attributedText = Typography.attributed(
-      "분",
-      style: .headingXl(weight: .bold),
-      color: .appBlack
-    )
-    $0.textAlignment = .center
-  }
+//  // 접힘 UI일 때 중앙에 보이는 숫자/단위 라벨
+//  private let collapsedNumberLabel = UILabel().then {
+//    $0.attributedText = Typography.attributed(
+//      "50",
+//      style: .displayMd(weight: .semibold),
+//      color: .appBlack
+//    )
+//    $0.textAlignment = .center
+//  }
 
-  private lazy var collapsedValueStack = UIStackView(arrangedSubviews: [collapsedNumberLabel, collapsedUnitLabel]).then {
-    $0.axis = .horizontal
-    $0.alignment = .center
-    $0.spacing = 8
-  }
+//  private let collapsedUnitLabel = UILabel().then {
+//    $0.attributedText = Typography.attributed(
+//      "분",
+//      style: .headingXl(weight: .bold),
+//      color: .appBlack
+//    )
+//    $0.textAlignment = .center
+//  }
+
+//  private lazy var collapsedValueStack = UIStackView(arrangedSubviews: [collapsedNumberLabel, collapsedUnitLabel]).then {
+//    $0.axis = .horizontal
+//    $0.alignment = .center
+//    $0.spacing = 8
+//  }
 
   // 저장하기 버튼
   private let saveButton = UIButton(type: .system).then {
@@ -127,12 +138,20 @@ final class TimerEditViewController: UIViewController {
 
   private var goalContainerHeightConstraint: Constraint?
 
+  // 데이터
+  private let minuteOptions: [Int] = Array(stride(from: 5, through: 180, by: 5))
+  private var selectedMinutes: Int = 50
+
   // MARK: - Lifecycle
 
   override func viewDidLoad() {
     super.viewDidLoad()
     setupViewController()
     navigationController?.setNavigationBarHidden(true, animated: false)
+
+    if let idx = minuteOptions.firstIndex(of: selectedMinutes) {
+      minutePicker.selectRow(idx, inComponent: 0, animated: false)
+    }
   }
 
   // MARK: - Setup
@@ -148,7 +167,7 @@ final class TimerEditViewController: UIViewController {
     view.addSubviews(mainViews)
 
     goalContainerView.addSubviews([goalTitleLabel, goalValueArea])
-    goalValueArea.addSubview(collapsedValueStack)
+    goalValueArea.addSubview(minutePicker)
   }
 
   private func setupConstraints() {
@@ -187,7 +206,7 @@ final class TimerEditViewController: UIViewController {
     goalContainerView.snp.makeConstraints {
       $0.top.equalTo(emojiButton.snp.bottom).offset(Metrics.verticalSpacing)
       $0.leading.trailing.equalToSuperview().inset(Metrics.horizontalPadding)
-      goalContainerHeightConstraint = $0.height.equalTo(Metrics.goalContainerHeightCollapsed).constraint
+      goalContainerHeightConstraint = $0.height.greaterThanOrEqualTo(Metrics.goalContainerHeightCollapsed).constraint
     }
 
     goalTitleLabel.snp.makeConstraints {
@@ -200,8 +219,16 @@ final class TimerEditViewController: UIViewController {
       $0.bottom.equalToSuperview().inset(16)
     }
 
-    collapsedValueStack.snp.makeConstraints {
-      $0.center.equalToSuperview()
+    minutePicker.snp.makeConstraints {
+      $0.edges.equalToSuperview().inset(8)
+      $0.width.greaterThanOrEqualTo(Metrics.inlinePickerMinWidth)
+      $0.height.greaterThanOrEqualTo(Metrics.pickerRowHeight * 3)
+    }
+
+    saveButton.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview().inset(Metrics.horizontalPadding)
+      $0.height.equalTo(Metrics.buttonHeight)
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(Metrics.bottomSafeAreaInset)
     }
   }
 
@@ -217,5 +244,23 @@ final class TimerEditViewController: UIViewController {
 
   @objc private func backButtonTapped() {
     navigationController?.popViewController(animated: true)
+  }
+}
+
+// MARK: - UIPickerView DataSource & Delegate
+
+extension TimerEditViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+  func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
+  func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int { minuteOptions.count }
+  func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+    "\(minuteOptions[row])"
+  }
+
+  func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+    selectedMinutes = minuteOptions[row]
+  }
+
+  func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+    Metrics.pickerRowHeight
   }
 }

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -343,12 +343,27 @@ final class TimerEditViewController: UIViewController {
 extension TimerEditViewController: UIPickerViewDataSource, UIPickerViewDelegate {
   func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
   func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int { minuteOptions.count }
-  func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-    "\(minuteOptions[row])"
+  func pickerView(_ pickerView: UIPickerView,
+                  viewForRow row: Int,
+                  forComponent component: Int,
+                  reusing view: UIView?) -> UIView
+  {
+    let label = (view as? UILabel) ?? UILabel()
+    label.text = "\(minuteOptions[row])"
+    label.font = Typography.font(for: .displayMd(weight: .semibold))
+    label.textColor = .appBlack
+    label.textAlignment = .center
+    label.adjustsFontForContentSizeCategory = true
+
+    label.isAccessibilityElement = true
+    label.accessibilityLabel = "\(minuteOptions[row])분"
+
+    return label
   }
 
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
     selectedMinutes = minuteOptions[row]
+    if !isPickerExpanded { updateCollapsedLabelText() }
   }
 
   func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -19,7 +19,8 @@ final class TimerEditViewController: UIViewController {
     static let verticalSpacing: CGFloat = 12
     static let buttonHeight: CGFloat = 48
     static let emojiButtonSize: CGFloat = 56
-    static let goalContainerHeightCollapsed: CGFloat = 240
+    static let goalContainerHeightCollapsed: CGFloat = 112
+    static let goalContainerHeightExpanded: CGFloat = 312
     static let textFieldHeight: CGFloat = 56
     static let textFieldLeftPadding: CGFloat = 16
     static let topOffset: CGFloat = 32
@@ -29,6 +30,8 @@ final class TimerEditViewController: UIViewController {
     // Picker
     static let inlinePickerMinWidth: CGFloat = 90
     static let pickerRowHeight: CGFloat = 48
+    static let unitRightInset: CGFloat = 16
+    static let unitLeftSpacing: CGFloat = 8
   }
 
   // MARK: - UI Components
@@ -78,7 +81,7 @@ final class TimerEditViewController: UIViewController {
   private let goalTitleLabel = UILabel().then {
     $0.attributedText = Typography.attributed(
       "목표 집중 시간",
-      style: .labelLg(weight: .semibold),
+      style: .labelMd(weight: .semibold),
       color: Palette.Gray.g500
     )
   }
@@ -88,6 +91,7 @@ final class TimerEditViewController: UIViewController {
     $0.backgroundColor = .gray100
     $0.layer.cornerRadius = Metrics.cornerRadius
     $0.clipsToBounds = true
+    $0.isUserInteractionEnabled = true // 탭 제스처
   }
 
   // 분 선택 피커
@@ -95,32 +99,20 @@ final class TimerEditViewController: UIViewController {
     $0.dataSource = self
     $0.delegate = self
     $0.backgroundColor = .clear
+    $0.showsSelectionIndicator = false
   }
 
-//  // 접힘 UI일 때 중앙에 보이는 숫자/단위 라벨
-//  private let collapsedNumberLabel = UILabel().then {
-//    $0.attributedText = Typography.attributed(
-//      "50",
-//      style: .displayMd(weight: .semibold),
-//      color: .appBlack
-//    )
-//    $0.textAlignment = .center
-//  }
+  // 분 고정 유닛
+  private let unitLabel = UILabel().then {
+    $0.attributedText = Typography.attributed("분", style: .headingXl(weight: .semibold), color: .gray600)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    $0.setContentHuggingPriority(.required, for: .horizontal)
+  }
 
-//  private let collapsedUnitLabel = UILabel().then {
-//    $0.attributedText = Typography.attributed(
-//      "분",
-//      style: .headingXl(weight: .bold),
-//      color: .appBlack
-//    )
-//    $0.textAlignment = .center
-//  }
-
-//  private lazy var collapsedValueStack = UIStackView(arrangedSubviews: [collapsedNumberLabel, collapsedUnitLabel]).then {
-//    $0.axis = .horizontal
-//    $0.alignment = .center
-//    $0.spacing = 8
-//  }
+  // 접힘 상태에서 중앙값 표시
+  private let collapsedValueLabel = UILabel().then {
+    $0.textAlignment = .center
+  }
 
   // 저장하기 버튼
   private let saveButton = UIButton(type: .system).then {
@@ -137,8 +129,11 @@ final class TimerEditViewController: UIViewController {
   // MARK: - Constraints
 
   private var goalContainerHeightConstraint: Constraint?
+  private var minutePickerMinHeightConstraint: Constraint?
+  private var isPickerExpanded = false
 
-  // 데이터
+  // MARK: - Data
+
   private let minuteOptions: [Int] = Array(stride(from: 5, through: 180, by: 5))
   private var selectedMinutes: Int = 50
 
@@ -146,20 +141,29 @@ final class TimerEditViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    setupViewController()
+    view.backgroundColor = .gray100
     navigationController?.setNavigationBarHidden(true, animated: false)
+    addSubviews()
+    setupConstraints()
+
+    goalTitleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+    goalTitleLabel.setContentHuggingPriority(.required, for: .vertical)
+    goalValueArea.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+    minutePicker.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+    unitLabel.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
     if let idx = minuteOptions.firstIndex(of: selectedMinutes) {
       minutePicker.selectRow(idx, inComponent: 0, animated: false)
     }
+
+    goalValueArea.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(togglePicker)))
+    applyCollapsedUI(animated: false)
+    updateCollapsedLabelText()
   }
 
-  // MARK: - Setup
-
-  private func setupViewController() {
-    view.backgroundColor = .gray100
-    addSubviews()
-    setupConstraints()
+  // 점선 원 뷰
+  private let dashedCircleView = UIView().then {
+    $0.backgroundColor = .clear
   }
 
   private func addSubviews() {
@@ -167,18 +171,43 @@ final class TimerEditViewController: UIViewController {
     view.addSubviews(mainViews)
 
     goalContainerView.addSubviews([goalTitleLabel, goalValueArea])
-    goalValueArea.addSubview(minutePicker)
+    goalValueArea.addSubviews([minutePicker, unitLabel, collapsedValueLabel])
+
+    emojiButton.addSubview(dashedCircleView)
+    dashedCircleView.snp.makeConstraints {
+      $0.center.equalToSuperview()
+      $0.size.equalTo(Metrics.dashedCircleSize)
+    }
+  }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    // CAShapeLayer 점선 원 그리기
+    dashedCircleView.layer.sublayers?.forEach { $0.removeFromSuperlayer() }
+
+    let shapeLayer = CAShapeLayer()
+    let path = UIBezierPath(
+      ovalIn: CGRect(origin: .zero,
+                     size: CGSize(width: Metrics.dashedCircleSize,
+                                  height: Metrics.dashedCircleSize))
+    )
+    shapeLayer.path = path.cgPath
+    shapeLayer.strokeColor = Palette.Gray.g200.cgColor
+    shapeLayer.fillColor = UIColor.clear.cgColor
+    shapeLayer.lineWidth = 1
+    shapeLayer.lineDashPattern = [4, 2] // 4pt 그려지고 2pt 띄움
+    dashedCircleView.layer.addSublayer(shapeLayer)
   }
 
   private func setupConstraints() {
     setupHeaderConstraints()
     setupFormConstraints()
-    setupSaveButtonConstraints()
   }
 
   private func setupHeaderConstraints() {
     backButton.snp.makeConstraints {
-      $0.top.equalTo(view.safeAreaLayoutGuide).offset(2)
+      $0.top.equalTo(view.safeAreaLayoutGuide).offset(20)
       $0.leading.equalToSuperview().offset(16)
       $0.size.equalTo(28)
     }
@@ -206,7 +235,7 @@ final class TimerEditViewController: UIViewController {
     goalContainerView.snp.makeConstraints {
       $0.top.equalTo(emojiButton.snp.bottom).offset(Metrics.verticalSpacing)
       $0.leading.trailing.equalToSuperview().inset(Metrics.horizontalPadding)
-      goalContainerHeightConstraint = $0.height.greaterThanOrEqualTo(Metrics.goalContainerHeightCollapsed).constraint
+      goalContainerHeightConstraint = $0.height.equalTo(Metrics.goalContainerHeightCollapsed).constraint
     }
 
     goalTitleLabel.snp.makeConstraints {
@@ -219,10 +248,30 @@ final class TimerEditViewController: UIViewController {
       $0.bottom.equalToSuperview().inset(16)
     }
 
+    unitLabel.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.trailing.equalToSuperview().inset(Metrics.unitRightInset)
+    }
+
     minutePicker.snp.makeConstraints {
-      $0.edges.equalToSuperview().inset(8)
+      $0.centerY.equalToSuperview()
+      $0.leading.equalToSuperview()
+      $0.trailing.equalTo(unitLabel.snp.leading).offset(-Metrics.unitLeftSpacing)
+      $0.top.greaterThanOrEqualToSuperview()
+      $0.bottom.lessThanOrEqualToSuperview()
       $0.width.greaterThanOrEqualTo(Metrics.inlinePickerMinWidth)
-      $0.height.greaterThanOrEqualTo(Metrics.pickerRowHeight * 3)
+
+      minutePickerMinHeightConstraint = $0.height
+        .greaterThanOrEqualTo(Metrics.pickerRowHeight * 3)
+        .constraint
+    }
+
+    minutePickerMinHeightConstraint?.deactivate()
+
+    collapsedValueLabel.snp.makeConstraints {
+      $0.center.equalToSuperview()
+      $0.leading.greaterThanOrEqualToSuperview().offset(16)
+      $0.trailing.lessThanOrEqualToSuperview().inset(16)
     }
 
     saveButton.snp.makeConstraints {
@@ -232,18 +281,60 @@ final class TimerEditViewController: UIViewController {
     }
   }
 
-  private func setupSaveButtonConstraints() {
-    saveButton.snp.makeConstraints {
-      $0.leading.trailing.equalToSuperview().inset(Metrics.horizontalPadding)
-      $0.height.equalTo(Metrics.buttonHeight)
-      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(Metrics.bottomSafeAreaInset)
+  // MARK: - Collapsed/Expanded
+
+  private func updateCollapsedLabelText() {
+    // 숫자(마지막 글자에만 kerning 8)
+    let number = NSMutableAttributedString(
+      attributedString: Typography.attributed(
+        "\(selectedMinutes)", style: .displayMd(weight: .semibold), color: .appBlack
+      )
+    )
+    if number.length > 0 {
+      number.addAttribute(.kern, value: 8, range: NSRange(location: number.length - 1, length: 1))
     }
+
+    // 단위
+    let unit = Typography.attributed("분", style: .headingXl(weight: .semibold), color: .gray600)
+
+    number.append(unit)
+    collapsedValueLabel.attributedText = number
+  }
+
+  private func applyCollapsedUI(animated: Bool) {
+    isPickerExpanded = false
+    unitLabel.isHidden = true
+    minutePicker.isHidden = true
+    collapsedValueLabel.isHidden = false
+
+    minutePickerMinHeightConstraint?.deactivate()
+
+    goalContainerHeightConstraint?.update(offset: Metrics.goalContainerHeightCollapsed)
+    let changes = { self.view.layoutIfNeeded() }
+    animated ? UIView.animate(withDuration: 0.25, animations: changes) : changes()
+  }
+
+  private func applyExpandedUI(animated: Bool) {
+    isPickerExpanded = true
+    unitLabel.isHidden = false
+    minutePicker.isHidden = false
+    collapsedValueLabel.isHidden = true
+
+    minutePickerMinHeightConstraint?.activate()
+
+    goalContainerHeightConstraint?.update(offset: Metrics.goalContainerHeightExpanded)
+    let changes = { self.view.layoutIfNeeded() }
+    animated ? UIView.animate(withDuration: 0.28, delay: 0, usingSpringWithDamping: 0.9, initialSpringVelocity: 0.6, options: .curveEaseInOut, animations: changes) : changes()
   }
 
   // MARK: - Actions
 
   @objc private func backButtonTapped() {
     navigationController?.popViewController(animated: true)
+  }
+
+  @objc private func togglePicker() {
+    isPickerExpanded ? applyCollapsedUI(animated: true) : applyExpandedUI(animated: true)
   }
 }
 

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -19,13 +19,12 @@ final class TimerEditViewController: UIViewController {
     static let verticalSpacing: CGFloat = 12
     static let buttonHeight: CGFloat = 48
     static let emojiButtonSize: CGFloat = 56
-    static let goalContainerHeight: CGFloat = 113
+    static let goalContainerHeightCollapsed: CGFloat = 112
     static let textFieldHeight: CGFloat = 56
     static let textFieldLeftPadding: CGFloat = 16
     static let topOffset: CGFloat = 32
     static let bottomSafeAreaInset: CGFloat = 20
     static let dashedCircleSize: CGFloat = 40
-    static let dashPattern: [NSNumber] = [4, 2]
   }
 
   // MARK: - UI Components
@@ -82,36 +81,34 @@ final class TimerEditViewController: UIViewController {
 
   // 숫자/분 들어가는 회색 영역
   private let goalValueArea = UIView().then {
-    $0.backgroundColor = .gray50
+    $0.backgroundColor = .gray100
     $0.layer.cornerRadius = Metrics.cornerRadius
     $0.clipsToBounds = true
   }
 
-  // 목표시간 표시 스택 (숫자 + 단위)
-  private lazy var goalValueStack = UIStackView().then {
-    $0.addArrangedSubviews([goalValueNumberLabel, goalValueUnitLabel])
-    $0.axis = .horizontal
-    $0.alignment = .center
-    $0.distribution = .fill
-    $0.spacing = 6
-  }
-
-  // 목표시간 숫자 (default: 50)
-  private let goalValueNumberLabel = UILabel().then {
+  // 접힘 UI일 때 중앙에 보이는 숫자/단위 라벨
+  private let collapsedNumberLabel = UILabel().then {
     $0.attributedText = Typography.attributed(
       "50",
-      style: .displayMd(weight: .bold),
+      style: .displayMd(weight: .semibold),
       color: .appBlack
     )
+    $0.textAlignment = .center
   }
 
-  // 목표시간 단위 (분으로 고정)
-  private let goalValueUnitLabel = UILabel().then {
+  private let collapsedUnitLabel = UILabel().then {
     $0.attributedText = Typography.attributed(
       "분",
-      style: .headingLg,
-      color: Palette.Gray.g500
+      style: .headingXl(weight: .bold),
+      color: .appBlack
     )
+    $0.textAlignment = .center
+  }
+
+  private lazy var collapsedValueStack = UIStackView(arrangedSubviews: [collapsedNumberLabel, collapsedUnitLabel]).then {
+    $0.axis = .horizontal
+    $0.alignment = .center
+    $0.spacing = 8
   }
 
   // 저장하기 버튼
@@ -124,13 +121,11 @@ final class TimerEditViewController: UIViewController {
       for: .normal
     )
     $0.isEnabled = true
-    // 저장 액션 추가 예정
-    // $0.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
   }
 
-  // MARK: - Dashed circle layer reference
+  // MARK: - Constraints
 
-  private var dashedCircleLayer: CAShapeLayer? // 점선 원 레이어를 프로퍼티로 보관
+  private var goalContainerHeightConstraint: Constraint?
 
   // MARK: - Lifecycle
 
@@ -140,12 +135,7 @@ final class TimerEditViewController: UIViewController {
     navigationController?.setNavigationBarHidden(true, animated: false)
   }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    updateDashedCircle() // 레이아웃 시 프레임 갱신/생성
-  }
-
-  // MARK: - Private Methods
+  // MARK: - Setup
 
   private func setupViewController() {
     view.backgroundColor = .gray100
@@ -157,10 +147,8 @@ final class TimerEditViewController: UIViewController {
     let mainViews = [backButton, titleLabel, emojiButton, nameTextField, goalContainerView, saveButton]
     view.addSubviews(mainViews)
 
-    let goalContainerSubviews = [goalTitleLabel, goalValueArea]
-    goalContainerView.addSubviews(goalContainerSubviews)
-
-    goalValueArea.addSubview(goalValueStack)
+    goalContainerView.addSubviews([goalTitleLabel, goalValueArea])
+    goalValueArea.addSubview(collapsedValueStack)
   }
 
   private func setupConstraints() {
@@ -199,13 +187,9 @@ final class TimerEditViewController: UIViewController {
     goalContainerView.snp.makeConstraints {
       $0.top.equalTo(emojiButton.snp.bottom).offset(Metrics.verticalSpacing)
       $0.leading.trailing.equalToSuperview().inset(Metrics.horizontalPadding)
-      $0.height.equalTo(Metrics.goalContainerHeight)
+      goalContainerHeightConstraint = $0.height.equalTo(Metrics.goalContainerHeightCollapsed).constraint
     }
 
-    setupGoalContainerConstraints()
-  }
-
-  private func setupGoalContainerConstraints() {
     goalTitleLabel.snp.makeConstraints {
       $0.leading.top.equalToSuperview().offset(16)
     }
@@ -216,7 +200,7 @@ final class TimerEditViewController: UIViewController {
       $0.bottom.equalToSuperview().inset(16)
     }
 
-    goalValueStack.snp.makeConstraints {
+    collapsedValueStack.snp.makeConstraints {
       $0.center.equalToSuperview()
     }
   }
@@ -229,36 +213,7 @@ final class TimerEditViewController: UIViewController {
     }
   }
 
-  // MARK: - Dashed Circle (이모지 버튼 안쪽 점선 원)
-
-  private func updateDashedCircle() {
-    // 중앙에 배치할 원의 frame 계산
-    let centerX = emojiButton.bounds.midX
-    let centerY = emojiButton.bounds.midY
-    let radius = Metrics.dashedCircleSize / 2
-    let circleFrame = CGRect(
-      x: centerX - radius,
-      y: centerY - radius,
-      width: Metrics.dashedCircleSize,
-      height: Metrics.dashedCircleSize
-    )
-
-    if let layer = dashedCircleLayer {
-      // 이미 존재하면 path만 갱신
-      layer.path = UIBezierPath(ovalIn: circleFrame).cgPath
-      return
-    }
-
-    let layer = CAShapeLayer()
-    layer.strokeColor = Palette.Gray.g300.cgColor
-    layer.fillColor = UIColor.clear.cgColor
-    layer.lineDashPattern = Metrics.dashPattern
-    layer.lineWidth = 1
-    layer.path = UIBezierPath(ovalIn: circleFrame).cgPath
-
-    emojiButton.layer.addSublayer(layer)
-    dashedCircleLayer = layer
-  }
+  // MARK: - Actions
 
   @objc private func backButtonTapped() {
     navigationController?.popViewController(animated: true)

--- a/PodoIt/Scenes/Timer/View/TimerViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerViewController.swift
@@ -94,6 +94,8 @@ final class TimerViewController: UIViewController, UICollectionViewDelegateFlowL
 
   override func viewDidLoad() {
     super.viewDidLoad()
+    navigationController?.setNavigationBarHidden(true, animated: false)
+    navigationItem.largeTitleDisplayMode = .never
     configureUI()
     addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- #24

## 🔧 PR 요약

- 목표 집중 시간 Picker UI 구현

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

<img width="300" height="700" alt="simulator_screenshot_06B63251-C623-41B7-9C6D-7FE1CFB48647" src="https://github.com/user-attachments/assets/d1ebd98d-11e5-468f-88fe-1c912fdf554e" />


## 📎 기타 참고사항

> Picker 안 시간이랑 분 부분 정렬 다른 거 수정 예정
Picker 안 시간 스크롤 UI 수정 예정