### PR TITLE
feat: #37 - 타이머 데이터 전달 및 탭바 숨김 처리

### DIFF
--- a/PodoIt/Data/SwiftDataManager.swift
+++ b/PodoIt/Data/SwiftDataManager.swift
@@ -82,7 +82,7 @@ final class SwiftDataManager: TimerRepository {
 
   // MARK: - Helper
 
-  private func fetch(by id: UUID) throws -> TimerModel? {
+  func fetch(by id: UUID) throws -> TimerModel? {
     let predicate = #Predicate<TimerModel> { $0.timerID == id }
     var descriptor = FetchDescriptor<TimerModel>(predicate: predicate)
     descriptor.fetchLimit = 1

--- a/PodoIt/Scenes/Timer/Repository/TimerRepository.swift
+++ b/PodoIt/Scenes/Timer/Repository/TimerRepository.swift
@@ -11,6 +11,7 @@ import Foundation
 // 타이머 데이터를 다루는 추상화 인터페이스
 protocol TimerRepository {
   func fetchAll() throws -> [TimerModel] // 모든 타이머 조회
+  func fetch(by id: UUID) throws -> TimerModel? // 단일 타이머 조회
   @discardableResult
   func insert(title: String, iconName: String, goalMinutes: Int) throws -> TimerModel // 생성
   func update(id: UUID, title: String, iconName: String, goalMinutes: Int) throws // 수정

--- a/PodoIt/Scenes/Timer/View/TimerViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerViewController.swift
@@ -217,19 +217,14 @@ extension TimerViewController: UICollectionViewDataSource {
     let model = timers[indexPath.item]
     cell.configure(with: model)
 
-//    // 셀 → VC로 버튼 탭 이벤트 전달
-//    cell.onPlayTapped = { [weak self] in
-//      guard let self = self else { return }
-//      let timer = self.timers[indexPath.item]
-//      // 타이머 실행 화면으로 이동
-//      let runningVC = TimerRunningViewController(timer: timer, repository: self.repository)
-//      self.navigationController?.pushViewController(runningVC, animated: true)
-//    }
-
+    // 셀 → VC로 버튼 탭 이벤트 전달
     cell.onPlayTapped = { [weak self] in
       guard let self = self else { return }
       let timer = self.timers[indexPath.item]
-      print("타이머 실행: \(timer.title)")
+      // 타이머 실행 화면으로 이동
+      let runVC = TimerRunViewController(timerID: timer.timerID, repo: self.repository) // UUID 전달
+      runVC.hidesBottomBarWhenPushed = true // 탭바 숨기기
+      self.navigationController?.pushViewController(runVC, animated: true)
     }
 
     return cell

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -1,0 +1,38 @@
+//
+//  TimerRunViewController.swift
+//  PodoIt
+//
+//  Created by 서광용 on 8/28/25.
+//
+
+import UIKit
+
+final class TimerRunViewController: UIViewController {
+  private let viewModel: TimerRunViewModel
+
+  init(timerID: UUID, repo: TimerRepository) {
+    self.viewModel = TimerRunViewModel(timerID: timerID, repo: repo)
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .purple
+    do {
+      try viewModel.load()
+      if let timer = viewModel.timer {
+        print(timer.timerID)
+        print(timer.title)
+        print(timer.iconName)
+        print(timer.goalTime)
+      }
+    } catch {
+      print("실패: \(error.localizedDescription)")
+    }
+  }
+}

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  TimerRunViewModel.swift
+//  PodoIt
+//
+//  Created by 서광용 on 8/28/25.
+//
+
+import Foundation
+
+final class TimerRunViewModel {
+  private let timerID: UUID
+  private let repo: TimerRepository
+
+  private(set) var timer: TimerModel?
+
+  init(timerID: UUID, repo: TimerRepository) {
+    self.timerID = timerID
+    self.repo = repo
+  }
+
+  func load() throws {
+    guard let entity = try repo.fetch(by: timerID) else {
+      throw RepositoryError.entityNotFound
+    }
+    self.timer = entity
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- #37  

## 🔧 PR 요약
- 초기 세팅만 하였으며, 임시로 간단하게 `print()`로 데이터 받아온 것을 확인했습니다.
- TimerRepository에 단일 타이머 조회 메서드(fetch by id) private 해제
- Timer 리스트 셀 ▶ 버튼 탭 시 TimerRunVC로 UUID와 repo 전달
- 실행 화면 VC에서 ViewModel을 통해 데이터 로드 가능하도록 연결
- 실행 화면 push 시 탭바 숨김(hidesBottomBarWhenPushed) 적용
- TimerRunVC에서 print문으로 작동 확인

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
> 화면 push 동작만 확인 (탭바 없는 상태로)
![Image](https://github.com/user-attachments/assets/2422f2b6-58b5-409c-8152-aa0bafa956ae)

> print()로 데이터 확인
<img width="306" height="101" alt="image" src="https://github.com/user-attachments/assets/a1bcf523-20bb-4998-be08-b11ceabb95d8" />

## 📎 기타 참고사항
