### PR TITLE
feat: #53 - 통계 화면 캘린더 기능 구현

### DIFF
--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarCell.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarCell.swift
@@ -8,13 +8,27 @@
 import UIKit
 
 final class CalendarCell: UICollectionViewCell {
-  static let identifier = "CalendarCollectionViewCell"
+  static let identifier = "CalendarCell"
 
   // MARK: - Properties
 
   private lazy var dayLabel = UILabel().then {
     $0.textColor = .gray800
     $0.font = Typography.font(for: .labelMd(weight: .regular))
+  }
+
+  private let selectionView = UIView().then {
+    $0.backgroundColor = .appWhite
+    $0.layer.borderWidth = 1
+    $0.layer.borderColor = UIColor.primary500.cgColor
+    $0.layer.cornerRadius = 18
+    $0.isHidden = true
+  }
+
+  override var isSelected: Bool {
+    didSet {
+      selectionView.isHidden = !isSelected
+    }
   }
 
   // MARK: - Init
@@ -31,6 +45,18 @@ final class CalendarCell: UICollectionViewCell {
 
   // MARK: - Methods
 
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    let cornerRadius = selectionView.bounds.width / 2
+    selectionView.layer.cornerRadius = cornerRadius
+
+    let path = UIBezierPath(ovalIn: selectionView.bounds).cgPath
+    selectionView.layer.shadowPath = path
+    selectionView.layer.shadowColor = UIColor.primary600.cgColor
+    selectionView.layer.shadowOpacity = 0.20
+    selectionView.layer.shadowRadius = 12
+  }
+
   override func prepareForReuse() {
     dayLabel.text = nil
   }
@@ -40,8 +66,13 @@ final class CalendarCell: UICollectionViewCell {
   }
 
   private func configure() {
-    [dayLabel].forEach {
+    [selectionView, dayLabel].forEach {
       addSubview($0)
+    }
+
+    selectionView.snp.makeConstraints {
+      $0.center.equalToSuperview()
+      $0.width.height.equalToSuperview().multipliedBy(0.8)
     }
 
     dayLabel.snp.makeConstraints {

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarView.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarView.swift
@@ -26,6 +26,8 @@ final class CalendarView: UIView {
 
   private let disposeBag = DisposeBag()
 
+  private var selectedIndexPath: IndexPath?
+
   private lazy var titleLabel = UILabel().then {
     $0.text = "2003년 01월"
     $0.font = Typography.font(for: .labelLg(weight: .semibold))
@@ -56,6 +58,7 @@ final class CalendarView: UIView {
     $0.dataSource = self
     $0.delegate = self
     $0.register(CalendarCell.self, forCellWithReuseIdentifier: CalendarCell.identifier)
+    $0.clipsToBounds = false
   }
 
   private let calendar = Calendar.current
@@ -179,6 +182,12 @@ extension CalendarView: UICollectionViewDataSource, UICollectionViewDelegate, UI
   {
     return 0
   }
+
+  func collectionView(_: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard !days[indexPath.item].isEmpty else { return }
+    let selectedDay = days[indexPath.item]
+    print("선택된 날짜: \(titleLabel.text ?? "") \(selectedDay)일")
+  }
 }
 
 extension CalendarView {
@@ -207,19 +216,39 @@ extension CalendarView {
 
   private func updateDays() {
     days.removeAll()
+    selectedIndexPath = nil // 달이 바뀔 때마다 초기화
+
     let startDayOfTheWeek = self.startDayOfTheWeek()
     let totalDays = startDayOfTheWeek + endDate()
 
-    for day in Int() ..< totalDays {
+    let todayComponents = calendar.dateComponents([.year, .month, .day], from: Date())
+    let currentComponents = calendar.dateComponents([.year, .month], from: calendarDate)
+
+    for day in 0 ..< totalDays {
       if day < startDayOfTheWeek {
-        days.append(String())
+        days.append("")
         continue
       }
-      days.append("\(day - startDayOfTheWeek + 1)")
+      let dayNumber = day - startDayOfTheWeek + 1
+      days.append("\(dayNumber)")
+
+      // 오늘 날짜일 때만 선택 IndexPath 저장
+      if todayComponents.year == currentComponents.year,
+         todayComponents.month == currentComponents.month,
+         todayComponents.day == dayNumber
+      {
+        selectedIndexPath = IndexPath(item: day, section: 0)
+      }
     }
 
     collectionView.reloadData()
     collectionView.layoutIfNeeded()
+
+    // 오늘 날짜가 있는 달일 때만 선택 적용
+    if let indexPath = selectedIndexPath {
+      collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+    }
+
     updateCollectionViewHeight()
   }
 

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Summary/Tabbar/StatsCustomSegmentedControl.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Summary/Tabbar/StatsCustomSegmentedControl.swift
@@ -70,8 +70,9 @@ final class SegmentHighlightLayer: CALayer {
   private func setupLayer() {
     backgroundColor = UIColor.appWhite.cgColor // Chip 색상
     shadowColor = UIColor.appBlack.cgColor // Shadow 색상
-    shadowOffset = CGSize(width: 0, height: 2) // Shadow Offset X: 0, Y: 2
-    shadowOpacity = 0.08 // Shadow opacity 8%
+    shadowOffset = CGSize(width: 0, height: 2) // Shadow 위치 X: 0, Y: 2
+    shadowOpacity = 0.08 // Shadow 불투명도 8%
+    shadowRadius = 16 // Shadow 블러
   }
 
   func updateFrame(_ frame: CGRect, animated: Bool) {


### PR DESCRIPTION
## 🔗 관련 이슈

- #53 

## 🔧 PR 요약

- 통계 화면 초기 진입시 캘린더 오늘 날짜로 선택
- 다른 날짜 선택시 날짜 print
- 탭바 Chip 그림자 수정

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷

https://github.com/user-attachments/assets/5f7dc240-63a7-4e65-8412-16f35d61e1eb