### PR TITLE
feat: #57 - 통계 화면 캘린더 색상 설명 UI 구현

### DIFF
--- a/PodoIt/Scenes/Stats/View/StatsViewController.swift
+++ b/PodoIt/Scenes/Stats/View/StatsViewController.swift
@@ -5,8 +5,8 @@
 //  Created by 노가현 on 8/20/25.
 //
 
-import Then
 import SnapKit
+import Then
 import UIKit
 
 final class StatsViewController: UIViewController {
@@ -14,6 +14,7 @@ final class StatsViewController: UIViewController {
 
   private let headerView = StatsHeaderView()
   private let calendarView = CalendarView()
+  private let calendarColorView = CalendarColorView()
   private let summaryView = StatsSummaryView()
 
   private let scrollView = UIScrollView().then {
@@ -45,7 +46,8 @@ final class StatsViewController: UIViewController {
   private func setupViews() {
     [headerView, scrollView].forEach { view.addSubview($0) }
     scrollView.addSubview(contentStackView)
-    [calendarView, summaryView].forEach { contentStackView.addArrangedSubview($0) }
+    [calendarView, calendarColorView, summaryView].forEach { contentStackView.addArrangedSubview($0) }
+    calendarView.layer.zPosition = 1
   }
 
   private func setupConstraints() {

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarCell.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarCell.swift
@@ -19,9 +19,8 @@ final class CalendarCell: UICollectionViewCell {
 
   private let selectionView = UIView().then {
     $0.backgroundColor = .appWhite
-    $0.layer.borderWidth = 1
-    $0.layer.borderColor = UIColor.primary500.cgColor
-    $0.layer.cornerRadius = 18
+    $0.layer.borderWidth = 1.5
+    $0.layer.borderColor = UIColor.primary700.cgColor
     $0.isHidden = true
   }
 
@@ -52,8 +51,8 @@ final class CalendarCell: UICollectionViewCell {
 
     let path = UIBezierPath(ovalIn: selectionView.bounds).cgPath
     selectionView.layer.shadowPath = path
-    selectionView.layer.shadowColor = UIColor.primary600.cgColor
-    selectionView.layer.shadowOpacity = 0.20
+    selectionView.layer.shadowColor = UIColor.primary700.withAlphaComponent(0.2).cgColor
+    selectionView.layer.shadowOpacity = 1
     selectionView.layer.shadowRadius = 12
   }
 

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorModel.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorModel.swift
@@ -1,0 +1,13 @@
+//
+//  CalendarColorModel.swift
+//  PodoIt
+//
+//  Created by 김이든 on 8/30/25.
+//
+
+import UIKit
+
+struct CalendarColorModel {
+  var time: String
+  var color: UIColor
+}

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorView.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorView.swift
@@ -1,0 +1,154 @@
+//
+//  CalendarColorView.swift
+//  PodoIt
+//
+//  Created by 김이든 on 8/29/25.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class CalendarColorView: UIView {
+  // MARK: - Metrics
+
+  private enum Layout {
+    static let horizontalPadding: CGFloat = 20
+    static let verticalPadding: CGFloat = 8
+    static let hStackSpacing: CGFloat = 12
+    static let dividerViewHeight: CGFloat = 1
+  }
+
+  // MARK: - Properties
+
+  private let container = PaddedContainerView(horizontal: Layout.horizontalPadding, vertical: Layout.verticalPadding).then {
+    $0.backgroundColor = .appWhite
+  }
+
+  private lazy var hStack = UIStackView().then {
+    $0.axis = .horizontal
+    $0.spacing = Layout.hStackSpacing
+    $0.alignment = .center
+    $0.distribution = .fill
+  }
+
+  private let dividerView = UIView().then {
+    $0.backgroundColor = .gray100
+  }
+
+  private let times = ["0분", "~1시간", "1~2시간", "2~3시간", "3시간+"]
+  private let colors: [UIColor] = [.appWhite, .primary100, .primary300, .primary500, .primary700]
+  private let stroke = 0
+
+  // MARK: - Init
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configureUI()
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Methods
+
+  private func configureUI() {
+    makeCalendarColorViews()
+    setupConstraints()
+  }
+
+  private func makeCalendarColorViews() {
+    for (index, time) in times.enumerated() {
+      let view = CircleLabelView(
+        text: time,
+        color: colors[index],
+        isSelected: index == stroke // 첫 번째만 Stoke
+      )
+
+      hStack.addArrangedSubview(view)
+    }
+    [container, dividerView].forEach { addSubview($0) }
+    [hStack].forEach { container.contentView.addSubview($0) }
+  }
+
+  private func setupConstraints() {
+    container.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+
+    dividerView.snp.makeConstraints {
+      $0.top.equalTo(container)
+      $0.directionalHorizontalEdges.equalToSuperview()
+      $0.height.equalTo(Layout.dividerViewHeight)
+    }
+
+    hStack.snp.makeConstraints {
+      $0.directionalVerticalEdges.equalToSuperview()
+      $0.centerX.equalToSuperview()
+    }
+  }
+}
+
+final class CircleLabelView: UIView {
+  // MARK: - Metrics
+
+  private enum Layout {
+    static let circleViewSize: CGFloat = 12
+    static let stackSpacing: CGFloat = 4
+    static let borderWidth: CGFloat = 1
+  }
+  
+  // MARK: - Properties
+
+  private let circleView = UIView()
+  private let label = UILabel()
+
+  // MARK: - Init
+
+  init(text: String, color: UIColor, isSelected: Bool = false) {
+    super.init(frame: .zero)
+    setupCircle(color: color, isSelected: isSelected)
+    setupLabel(text: text)
+    setupLayout()
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError()
+  }
+
+  // MARK: - Methods
+
+  private func setupCircle(color: UIColor, isSelected: Bool) {
+    circleView.backgroundColor = color
+    circleView.layer.cornerRadius = Layout.circleViewSize / 2
+
+    if isSelected {
+      circleView.layer.borderColor = UIColor.gray100.cgColor
+      circleView.layer.borderWidth = Layout.borderWidth
+    }
+  }
+
+  private func setupLabel(text: String) {
+    label.text = text
+    label.font = Typography.font(for: .captionLg(weight: .regular))
+    label.textColor = .gray500
+  }
+
+  private func setupLayout() {
+    let stack = UIStackView(arrangedSubviews: [circleView, label])
+    stack.axis = .horizontal
+    stack.spacing = Layout.stackSpacing
+    stack.alignment = .center
+
+    addSubview(stack)
+    stack.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+
+    circleView.snp.makeConstraints { $0.size.equalTo(Layout.circleViewSize)
+    }
+  }
+}

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorView.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorView.swift
@@ -99,7 +99,7 @@ final class CircleLabelView: UIView {
     static let stackSpacing: CGFloat = 4
     static let borderWidth: CGFloat = 1
   }
-  
+
   // MARK: - Properties
 
   private let circleView = UIView()

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorView.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorView.swift
@@ -148,7 +148,6 @@ final class CircleLabelView: UIView {
       $0.edges.equalToSuperview()
     }
 
-    circleView.snp.makeConstraints { $0.size.equalTo(Layout.circleViewSize)
-    }
+    circleView.snp.makeConstraints { $0.size.equalTo(Layout.circleViewSize) }
   }
 }

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorView.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Calendar/CalendarColorView.swift
@@ -36,8 +36,13 @@ final class CalendarColorView: UIView {
     $0.backgroundColor = .gray100
   }
 
-  private let times = ["0분", "~1시간", "1~2시간", "2~3시간", "3시간+"]
-  private let colors: [UIColor] = [.appWhite, .primary100, .primary300, .primary500, .primary700]
+  private let items: [CalendarColorModel] = [
+    CalendarColorModel(time: "0분", color: UIColor.appWhite),
+    CalendarColorModel(time: "~1시간", color: UIColor.primary100),
+    CalendarColorModel(time: "1~2시간", color: UIColor.primary300),
+    CalendarColorModel(time: "2~3시간", color: UIColor.primary500),
+    CalendarColorModel(time: "3시간+", color: UIColor.primary700),
+  ]
   private let stroke = 0
 
   // MARK: - Init
@@ -60,10 +65,10 @@ final class CalendarColorView: UIView {
   }
 
   private func makeCalendarColorViews() {
-    for (index, time) in times.enumerated() {
+    for (index, item) in items.enumerated() {
       let view = CircleLabelView(
-        text: time,
-        color: colors[index],
+        text: item.time,
+        color: item.color,
         isSelected: index == stroke // 첫 번째만 Stoke
       )
 


### PR DESCRIPTION
## 🔗 관련 이슈

- #57 

## 🔧 PR 요약

- 통계 화면 캘린더 색상 설명 UI 구현
- 캘린더 선택 UI 업데이트

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷
<img width="300" height="700" alt="simulator_screenshot_26AECD32-D4FD-42CB-865D-4B74D32154C1" src="https://github.com/user-attachments/assets/906c061c-99f5-46eb-8064-d7c07ff7b9b8" />

