### PR TITLE
feat: #56 - Rx기반의 타이머 실행/일시정지/재개/정지 로직 구현

### DIFF
--- a/PodoIt/Scenes/TimerRun/View/Sections/ButtonSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/ButtonSectionView.swift
@@ -5,6 +5,7 @@
 //  Created by 서광용 on 8/28/25.
 //
 
+import RxCocoa
 import SnapKit
 import Then
 import UIKit
@@ -21,7 +22,6 @@ final class ButtonSectionView: UIView {
     $0.tintColor = .appBlack
     $0.layer.cornerRadius = 32 // 버튼이 고정값이라 값 명시
     $0.clipsToBounds = true
-    $0.addTarget(self, action: #selector(didTapStopButton), for: .touchUpInside)
   }
   
   private lazy var startPauseButton = UIButton(type: .system).then {
@@ -30,7 +30,6 @@ final class ButtonSectionView: UIView {
     $0.backgroundColor = .primary600
     $0.layer.cornerRadius = 32
     $0.clipsToBounds = true
-    $0.addTarget(self, action: #selector(didTapStartPauseButton), for: .touchUpInside)
   }
   
   override init(frame: CGRect) {
@@ -60,12 +59,17 @@ final class ButtonSectionView: UIView {
       item.snp.makeConstraints { $0.size.equalTo(64) }
     }
   }
-  
-  @objc private func didTapStopButton() {
-    print("눌림")
+}
+
+extension ButtonSectionView {
+  /// addTarget과 같은 역할을 Rx로 감싼 코드.
+  /// - return의 startPauseButton.rx.tap으로, 그 버튼의 tap 이벤트 스트림을 반환함
+  /// - VC에서 반환값을 구독해서 연결되는 형태
+  var startPauseTap: ControlEvent<Void> {
+    return startPauseButton.rx.tap
   }
   
-  @objc private func didTapStartPauseButton() {
-    print("눌림")
+  var stopButtonTap: ControlEvent<Void> {
+    return stopButton.rx.tap
   }
 }

--- a/PodoIt/Scenes/TimerRun/View/Sections/TimerSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/TimerSectionView.swift
@@ -32,7 +32,7 @@ final class TimerSectionView: UIView {
     color: .gray900
   )
 
-  private let runningTimeLabel = UILabel.makeAttributed(
+  private(set) var runningTimeLabel = UILabel.makeAttributed(
     text: "0:00:00",
     style: .displayLg(weight: .bold),
     color: .appBlack,

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -66,8 +66,8 @@ final class TimerRunViewController: UIViewController {
       })
       .disposed(by: disposeBag)
 
-    // 여기서 ViewModel의 text 구독
-    // .drive로 받아서, 타이머 섹션의 텍스트에다가 바인딩.
-    // 디스포즈백!
+    viewModel.runningTimeText
+      .drive(timerView.runningTimeLabel.rx.text)
+      .disposed(by: disposeBag)
   }
 }

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -80,11 +80,22 @@ final class TimerRunViewController: UIViewController {
       .withUnretained(self)
       .bind(onNext: { vc, _ in
         vc.viewModel.stop()
+        vc.navigationController?.popViewController(animated: true) // pop되면서 interval도 중지
       })
       .disposed(by: disposeBag)
 
     viewModel.runningTimeText
+      .asObservable() // .take(until:)가 Observable 연산자라서 변경
+      // .take(until:): 원본 스트림을 유지하다가, 어떤 신호가 오면 즉시 "complete(종료)"시킴.
+      // viewWillDisappear가 불릴 때 이벤트 방출. 신호받고 complete -> 구독이 dispose -> interval 스케줄링도 멈춤
+      // 당장은 pop이라 없어도 문제 없겠지만, push하거나 modal 등으로 바뀔 수 있으니 유지.
+      .take(until: rx.methodInvoked(#selector(UIViewController.viewWillDisappear(_:))))
+      .asDriver(onErrorJustReturn: "0:00:00")
       .drive(timerView.runningTimeLabel.rx.text)
       .disposed(by: disposeBag)
+  }
+  
+  deinit {
+    print(" ---> [Deinit 확인!] 구독해제!")
   }
 }

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -58,11 +58,11 @@ final class TimerRunViewController: UIViewController {
   }
 
   private func bind() {
-    // 버튼 Tap을 스트림으로 받아서 viewModel의 start실행
+    // 버튼 Tap을 스트림으로 받아서 viewModel의 토글 실행 (start/pause)
     buttonBarView.startPauseTap
       .withUnretained(self)
       .bind(onNext: { vc, _ in
-        vc.viewModel.start()
+        vc.viewModel.startAndPause()
       })
       .disposed(by: disposeBag)
 

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -15,6 +15,7 @@ final class TimerRunViewController: UIViewController {
   private let disposeBag = DisposeBag()
 
   init(timerID: UUID, repo: TimerRepository) {
+    // UUID를 받아올 때마다 새로운 VM을 생성
     self.viewModel = TimerRunViewModel(timerID: timerID, repo: repo)
     super.init(nibName: nil, bundle: nil)
   }
@@ -44,7 +45,16 @@ final class TimerRunViewController: UIViewController {
     view.backgroundColor = .appWhite
     configureUI()
     configureLayout()
+    loadData()
     bind()
+  }
+
+  private func loadData() {
+    do {
+      try viewModel.load()
+    } catch {
+      print("타이머 데이터 로딩 실패: \(error)")
+    }
   }
 
   private func configureUI() {
@@ -63,6 +73,13 @@ final class TimerRunViewController: UIViewController {
       .withUnretained(self)
       .bind(onNext: { vc, _ in
         vc.viewModel.startAndPause()
+      })
+      .disposed(by: disposeBag)
+
+    buttonBarView.stopButtonTap
+      .withUnretained(self)
+      .bind(onNext: { vc, _ in
+        vc.viewModel.stop()
       })
       .disposed(by: disposeBag)
 

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -5,12 +5,14 @@
 //  Created by 서광용 on 8/28/25.
 //
 
+import RxSwift
 import SnapKit
 import Then
 import UIKit
 
 final class TimerRunViewController: UIViewController {
   private let viewModel: TimerRunViewModel
+  private let disposeBag = DisposeBag()
 
   init(timerID: UUID, repo: TimerRepository) {
     self.viewModel = TimerRunViewModel(timerID: timerID, repo: repo)
@@ -42,6 +44,7 @@ final class TimerRunViewController: UIViewController {
     view.backgroundColor = .appWhite
     configureUI()
     configureLayout()
+    bind()
   }
 
   private func configureUI() {
@@ -52,5 +55,19 @@ final class TimerRunViewController: UIViewController {
     rootStack.snp.makeConstraints {
       $0.directionalEdges.equalTo(view.safeAreaLayoutGuide)
     }
+  }
+
+  private func bind() {
+    // 버튼 Tap을 스트림으로 받아서 viewModel의 start실행
+    buttonBarView.startPauseTap
+      .withUnretained(self)
+      .bind(onNext: { vc, _ in
+        vc.viewModel.start()
+      })
+      .disposed(by: disposeBag)
+
+    // 여기서 ViewModel의 text 구독
+    // .drive로 받아서, 타이머 섹션의 텍스트에다가 바인딩.
+    // 디스포즈백!
   }
 }

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -17,27 +17,57 @@ final class TimerRunViewModel {
   private let disposeBag = DisposeBag()
   
   private let sessionStart = Date() // 공부 시작한 시간 기록
-  private var stateStart: Date? // 현재 구간(공부/휴식)이 시작된 시간 기록
+  private var stateStart = Date() // 현재 구간(공부/휴식)이 시작된 시간 기록
   private var isRunning = true // 공부 중(true)/휴식 중(false)
   
   private var studySeconds = 0 // 지금까지 누적된 총 공부 시간(초)
   private var restSeconds = 0 // 지금까지 누적된 총 휴식 시간(초)
   
-  let runningTimeText: Driver<String> // UI바인딩용. 공부시간을 방출
+  lazy var runningTimeText: Driver<String> = makeRunningTimeText() // UI바인딩용. 공부시간을 방출
   
+  // MARK: 시간 포맷터 ("h:mm:ss")
+
   private static func format(seconds: Int) -> String {
     let h = seconds / 3600
     let m = (seconds % 3600) / 60
     let s = seconds % 60
     return String(format: "%d:%02d:%02d", h, m, s) // 0:12:53, 1:50:49, 12:49:39등으로 포맷
   }
+  
+  // MARK: 공부시간 스트림
+
+  // UI의 라벨에 바인딩할 공부시간 문자열 Driver 생성
+  private func makeRunningTimeText() -> Driver<String> {
+    // 1초마다 아래의 map 블록 실행되며 runningTime부터 다시 계산.
+    // startWith(0)을 안붙여주면, 첫 이벤트가 1초 뒤에 옴.
+    let tick = Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.instance)
+      .startWith(0)
+    
+    return tick.withUnretained(self)
+      .map { vm, _ in
+        let now = Date()
+        // 공부중이면 stateStart부터 지금까지 흐른 초(seconds)를 계산
+        // 휴식중이면 실시간 경과는 0인 상태
+        let runningTime = vm.isRunning ? Int(now.timeIntervalSince(vm.stateStart)) : 0
+        
+        // 누적된 총 공부시간 + 진행중 공부 경과시간 계산
+        let totalStudyTime = vm.studySeconds + runningTime
+        
+        // 총 공부 시간을 "h:mm:ss" 형태 문자열로 반환
+        return TimerRunViewModel.format(seconds: totalStudyTime)
+      }
+      .distinctUntilChanged() // 이전값과 새 값이 같으면 방출안하고 무시
+      .asDriver(onErrorJustReturn: "0:00:00") // 에러나면 기본으로 "0:00:00" 방출
+  }
 
   init(timerID: UUID, repo: TimerRepository) {
     self.timerID = timerID
     self.repo = repo
-//    startAndPause()
   }
 
+  // MARK: 데이터 로딩
+
+  // 받아온 UUID를 기준으로 SwiftData에서 데이터를 바인딩
   func load() throws {
     guard let entity = try repo.fetch(by: timerID) else {
       throw RepositoryError.entityNotFound
@@ -48,5 +78,21 @@ final class TimerRunViewModel {
   func startAndPause() {
     // 여기에서 타이머 작동 로직
     // isRunning: Bool의 상태값을 기준으로, start/pause 상태로 관리
+    
+    let now = Date()
+    // 이번 구간의 시간(현재 시간 - 현재 구간(공부/휴식))
+    let time = Int(now.timeIntervalSince(stateStart))
+    
+    // 상태에 따라서 시간 누적
+    if isRunning {
+      studySeconds += time // 공부 시간 누적
+      print("현재까지 총 공부 시간: \(studySeconds)")
+    } else {
+      restSeconds += time // 휴식 시간 누적
+      print("현재까지 총 휴식 시간: \(restSeconds)")
+    }
+    
+    isRunning.toggle()
+    stateStart = now // 공부 <-> 휴식 상태가 바뀌니, 그 구간의 새 시각
   }
 }

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -12,11 +12,11 @@ import RxSwift
 final class TimerRunViewModel {
   private let timerID: UUID
   private let repo: TimerRepository
-
+  
   private(set) var timer: TimerModel?
   private let disposeBag = DisposeBag()
   
-  private let sessionStart = Date() // 공부 시작한 시간 기록
+  private var sessionStart = Date() // 공부 시작한 시간 기록
   private var stateStart = Date() // 현재 구간(공부/휴식)이 시작된 시간 기록
   private var isRunning = true // 공부 중(true)/휴식 중(false)
   
@@ -26,7 +26,7 @@ final class TimerRunViewModel {
   lazy var runningTimeText: Driver<String> = makeRunningTimeText() // UI바인딩용. 공부시간을 방출
   
   // MARK: 시간 포맷터 ("h:mm:ss")
-
+  
   private static func format(seconds: Int) -> String {
     let h = seconds / 3600
     let m = (seconds % 3600) / 60
@@ -35,7 +35,7 @@ final class TimerRunViewModel {
   }
   
   // MARK: 공부시간 스트림
-
+  
   // UI의 라벨에 바인딩할 공부시간 문자열 Driver 생성
   private func makeRunningTimeText() -> Driver<String> {
     // 1초마다 아래의 map 블록 실행되며 runningTime부터 다시 계산.
@@ -59,15 +59,16 @@ final class TimerRunViewModel {
       .distinctUntilChanged() // 이전값과 새 값이 같으면 방출안하고 무시
       .asDriver(onErrorJustReturn: "0:00:00") // 에러나면 기본으로 "0:00:00" 방출
   }
-
+  
   // MARK: init
+
   init(timerID: UUID, repo: TimerRepository) {
     self.timerID = timerID
     self.repo = repo
   }
-
+  
   // MARK: 데이터 로딩
-
+  
   // 받아온 UUID를 기준으로 SwiftData에서 데이터를 바인딩
   func load() throws {
     guard let entity = try repo.fetch(by: timerID) else {
@@ -75,8 +76,9 @@ final class TimerRunViewModel {
     }
     self.timer = entity
   }
-
+  
   // MARK: 시작/일시정지 버튼 tap
+
   func startAndPause() {
     // 여기에서 타이머 작동 로직
     // isRunning: Bool의 상태값을 기준으로, start/pause 상태로 관리
@@ -96,5 +98,47 @@ final class TimerRunViewModel {
     
     isRunning.toggle()
     stateStart = now // 공부 <-> 휴식 상태가 바뀌니, 그 구간의 새 시각
+  }
+  
+  // MARK: 정지 버튼 tap
+
+  func stop() {
+    let now = Date()
+    let lastTime = Int(now.timeIntervalSince(stateStart))
+    
+    if isRunning {
+      studySeconds += lastTime
+    } else {
+      // 혹시 필요할까 싶어서 총 휴식 시간도 누적계산
+      restSeconds += lastTime
+    }
+    
+    /*
+     
+     Models/StateModel의 StatsModel에 저장해야 하는 테이터들
+     var statsID: UUID
+     var date: Date
+     var icon: String
+     var category: String
+     var time: Int
+     
+     */
+    
+    // MARK: 저장 (여기서는 임시로 print로 대체)
+
+    print("""
+      
+      UUID: \(timer?.timerID ?? self.timerID), 
+      저장 기준 날짜(stop 버튼 tap한 UTC 기준): \(now), 
+      앱 아이콘: \(timer?.iconName ?? "아이콘 이름 없네요"), 
+      제목/카테고리 이름: \(timer?.title ?? "카테고리명이 왜 없지"), 
+      총 공부한 시간: \(studySeconds)초
+      총 공부 시간 format 적용: \(TimerRunViewModel.format(seconds: studySeconds))
+      
+      (혹시 몰라서 넣은)
+      총 휴식 시간: \(restSeconds)초
+      총 휴식 시간 format 적용: \(TimerRunViewModel.format(seconds: restSeconds))
+      """
+    )
   }
 }

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -128,10 +128,11 @@ final class TimerRunViewModel {
 
     print("""
       
-      UUID: \(timer?.timerID ?? self.timerID), 
-      저장 기준 날짜(stop 버튼 tap한 UTC 기준): \(now), 
-      앱 아이콘: \(timer?.iconName ?? "아이콘 이름 없네요"), 
-      제목/카테고리 이름: \(timer?.title ?? "카테고리명이 왜 없지"), 
+      UUID: \(timer?.timerID ?? self.timerID)
+      저장 기준 날짜(stop 버튼 tap한 UTC 기준): \(now)
+      앱 아이콘: \(timer?.iconName ?? "아이콘 이름 없네요")
+      제목/카테고리 이름: \(timer?.title ?? "카테고리명이 왜 없지")
+      목표 공부 시간: \(timer?.goalTime ?? 0)분
       총 공부한 시간: \(studySeconds)초
       총 공부 시간 format 적용: \(TimerRunViewModel.format(seconds: studySeconds))
       

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -6,12 +6,17 @@
 //
 
 import Foundation
+import RxCocoa
+import RxSwift
 
 final class TimerRunViewModel {
   private let timerID: UUID
   private let repo: TimerRepository
 
   private(set) var timer: TimerModel?
+
+  private let disposeBag = DisposeBag()
+  private let startDateRelay = BehaviorRelay<Date?>(value: nil) // 타이머 시작을 기억
 
   init(timerID: UUID, repo: TimerRepository) {
     self.timerID = timerID
@@ -23,5 +28,9 @@ final class TimerRunViewModel {
       throw RepositoryError.entityNotFound
     }
     self.timer = entity
+  }
+
+  func start() {
+    // 여기에서 타이머 작동 로직
   }
 }

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -14,13 +14,28 @@ final class TimerRunViewModel {
   private let repo: TimerRepository
 
   private(set) var timer: TimerModel?
-
   private let disposeBag = DisposeBag()
-  private let startDateRelay = BehaviorRelay<Date?>(value: nil) // 타이머 시작을 기억
+  
+  private let sessionStart = Date() // 공부 시작한 시간 기록
+  private var stateStart: Date? // 현재 구간(공부/휴식)이 시작된 시간 기록
+  private var isRunning = true // 공부 중(true)/휴식 중(false)
+  
+  private var studySeconds = 0 // 지금까지 누적된 총 공부 시간(초)
+  private var restSeconds = 0 // 지금까지 누적된 총 휴식 시간(초)
+  
+  let runningTimeText: Driver<String> // UI바인딩용. 공부시간을 방출
+  
+  private static func format(seconds: Int) -> String {
+    let h = seconds / 3600
+    let m = (seconds % 3600) / 60
+    let s = seconds % 60
+    return String(format: "%d:%02d:%02d", h, m, s) // 0:12:53, 1:50:49, 12:49:39등으로 포맷
+  }
 
   init(timerID: UUID, repo: TimerRepository) {
     self.timerID = timerID
     self.repo = repo
+//    startAndPause()
   }
 
   func load() throws {
@@ -30,7 +45,8 @@ final class TimerRunViewModel {
     self.timer = entity
   }
 
-  func start() {
+  func startAndPause() {
     // 여기에서 타이머 작동 로직
+    // isRunning: Bool의 상태값을 기준으로, start/pause 상태로 관리
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #56 

## 🔧 PR 요약
- `addTarget` 방식에서 Rx의 `ControlEvent`로 탭 이벤트 스트림 사용
- `viewModel.load()` 추가하여 SwiftData 데이터 바인딩
- 버튼 탭 시 동작 연결
  - `startPauseTap` -> `viewModel.startAndPause()`
  - `stopButtonTap` -> `viewModel.stop()` 실행 후 `popVC`로 화면 복귀
  - 이로 인해 `interval` 구독을 `dispose`하여, 메모리/CPU 낭비를 방지함
- 당장은 필요 없겠지만, pop되는 방식이 변경될 수도 있기에 `viewModel.runningTimeText` 바인딩 시에 `take(until: viewWillDisappear)` 적용하여, VC가 사라질 때 `interval` 스트림을 즉시 `compleate`시켜 메모리/CPU 낭비 방지.
- `runningTimeText`를 구현: 1초마다 갱신되는 공부 시간 `Driver(interval + 포맷터)`
- `startAndPause()` 구현: 현재 상태에 따라서 공부/휴식 시간 누적 및 상태 토글
- `stop()` 구현: 마지막 누적 시간 누적 후 공뷰/휴식 시간, 목표 시간, 카테고리명 등을 `print` 로그로 잘 나오는지 확인.
  - 추후 SwiftData에 저장하여 통계 화면에서 사용할 수 있도록 구현 예정


## ✅ 작업 내용 체크리스트
- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
![Image](https://github.com/user-attachments/assets/372f7e58-3966-47d5-92a8-38a17fba77cf)

## 📎 기타 참고사항