### PR TITLE
feat: #43 - 다크모드 인디게이터 크기 수정 및 알림설정 Label 변경

### DIFF
--- a/PodoIt/Scenes/Setting/Model/SettingModel.swift
+++ b/PodoIt/Scenes/Setting/Model/SettingModel.swift
@@ -27,7 +27,7 @@ enum SettingItem {
   
   var title: String {
     switch self {
-    case .notification: return "알림 설정"
+    case .notification: return "타이머 알림 소리"
     case .theme: return "테마 설정"
     case .inquiry: return "문의·건의하기"
     case .review: return "리뷰 남기기"

--- a/PodoIt/Scenes/Setting/View/ThemeSheet/ThemeSheetViewController.swift
+++ b/PodoIt/Scenes/Setting/View/ThemeSheet/ThemeSheetViewController.swift
@@ -96,7 +96,7 @@ final class ThemeSheetViewController: UIViewController {
     // 하단 safeAreaInsets 값(홈 인디게이터 있으면 34, 없으면 0)
      let bottomInset = view.safeAreaInsets.bottom
     // iPhone SE랑 비슷하게, 홈 인디게이터가 있다면 inset을 0으로줌.
-     let extraBottom: CGFloat = bottomInset > 0 ? 0 : Layout.sideInset
+     let extraBottom: CGFloat = bottomInset > 0 ? 0 : Layout.vSpacing
     
      saveButton.snp.remakeConstraints {
        $0.top.equalTo(tableView.snp.bottom).offset(Layout.vSpacing)

--- a/PodoIt/Scenes/Setting/View/ThemeSheet/ThemeSheetViewController.swift
+++ b/PodoIt/Scenes/Setting/View/ThemeSheet/ThemeSheetViewController.swift
@@ -14,8 +14,7 @@ final class ThemeSheetViewController: UIViewController {
     static let titleTop: CGFloat = 37 // grabber + padding
     
     static let sideInset: CGFloat = 20
-    static let vSpacingSmall: CGFloat = 16
-    static let vSpacing: CGFloat = 20
+    static let vSpacing: CGFloat = 16
     
     static let rowHeight: CGFloat = 56
     static let buttonHeight: CGFloat = 48
@@ -86,6 +85,27 @@ final class ThemeSheetViewController: UIViewController {
     configureLayout()
   }
   
+  // Safe Area Insets가 바뀔 때마다 호출
+  override func viewSafeAreaInsetsDidChange() {
+     super.viewSafeAreaInsetsDidChange()
+     updateSaveButtonConstraints()
+   }
+  
+  // saveButton 오토레이아웃 제약 업데이트
+  func updateSaveButtonConstraints() {
+    // 하단 safeAreaInsets 값(홈 인디게이터 있으면 34, 없으면 0)
+     let bottomInset = view.safeAreaInsets.bottom
+    // iPhone SE랑 비슷하게, 홈 인디게이터가 있다면 inset을 0으로줌.
+     let extraBottom: CGFloat = bottomInset > 0 ? 0 : Layout.sideInset
+    
+     saveButton.snp.remakeConstraints {
+       $0.top.equalTo(tableView.snp.bottom).offset(Layout.vSpacing)
+       $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(Layout.sideInset)
+       $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(extraBottom) // (홈 인디게이터 있으면 0, 없으면 sideInset)
+       $0.height.equalTo(Layout.buttonHeight)
+     }
+   }
+  
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     configureSheet() // 레이아웃 계산이 끝난 후, 실제 뷰 크기에 맞춰서 높이 설정
@@ -103,7 +123,7 @@ final class ThemeSheetViewController: UIViewController {
     }
 
     tableView.snp.makeConstraints {
-      $0.top.equalTo(titleLabel.snp.bottom).offset(Layout.vSpacingSmall)
+      $0.top.equalTo(titleLabel.snp.bottom).offset(Layout.vSpacing)
       $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
       $0.height.equalTo(CGFloat(Theme.allCases.count) * Layout.rowHeight) // 셀 3개 → 168
     }
@@ -111,7 +131,7 @@ final class ThemeSheetViewController: UIViewController {
     saveButton.snp.makeConstraints {
       $0.top.equalTo(tableView.snp.bottom).offset(Layout.vSpacing)
       $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(Layout.sideInset)
-      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(Layout.sideInset)
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(Layout.vSpacing)
       $0.height.equalTo(Layout.buttonHeight)
     }
   }

--- a/PodoIt/Scenes/Setting/ViewModel/SettingViewModel.swift
+++ b/PodoIt/Scenes/Setting/ViewModel/SettingViewModel.swift
@@ -28,7 +28,8 @@ final class SettingViewModel {
       // UserDefaults 저장과 UI는 완성. 어떤 상태를 했냐에 따라서 테마 변경만 지원하면 끝.
       // .theme(current: currentTheme),
       .inquiry,
-      .review
+      // TODO: 앱 배포 승인 후, appid 나오면 appid 수정 후 다시 노출
+      // .review
     ]
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #43 

## 🔧 PR 요약
- `viewSafeAreaInsetsDidChange`를 오버라이딩하여 홈 인디게이터 기준으로 `saveButton`의 `buttom` 제약 `rmake`
  - 홈 인디게이터가 있는 기기와, 없는 기기(iPhone SE 등)의 `bottom` 크기를 어느정도 맞춰주기 위해서
- `saveButton`의 `top`, `bottom` 여백을 20 -> 16으로 변경
- "알림 설정" Label을 "타이머 알림 소리"로 변경
- 리뷰 남기기 기능의 `appid`가 앱 스토어어 올라가야 생성되므로, 지금은 작동하지 않아서 셀에서 보이지 않도록 `items` 배열에서 주석처리

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
| iPhone 13 mini | iPhone SE (2nd gen) |
| -------------- | -------------------- |
| <img src="https://github.com/user-attachments/assets/2857a6db-6c27-4278-b6dd-4206b51f0a54" height="400"> | <img src="https://github.com/user-attachments/assets/cdbb8747-6a56-4f82-8682-f285af3b0b7f" height="400"> |

## 📎 기타 참고사항
- appid가 나오면 셀에서 보이도록 해서 이 앱의 앱스토어로 이동 가능하게 할 예정입니다. (기능 구현은 완료. appid만 수정하면 끝)
