### PR TITLE
feat: #48 - 타이머 종료 시 SwiftData에 State 모델 저장

### DIFF
--- a/PodoIt/Data/SwiftDataManager.swift
+++ b/PodoIt/Data/SwiftDataManager.swift
@@ -79,15 +79,8 @@ final class SwiftDataManager: TimerRepository {
       throw RepositoryError.saveFailed
     }
   }
-
-  // MARK: - Helper
-
-  func fetch(by id: UUID) throws -> TimerModel? {
-    let predicate = #Predicate<TimerModel> { $0.timerID == id }
-    var descriptor = FetchDescriptor<TimerModel>(predicate: predicate)
-    descriptor.fetchLimit = 1
-    return try modelContext.fetch(descriptor).first
-  }
+  
+  // MARK: - CRUD (StatsModel)
   
   @discardableResult
   func insertStats(date: Date = Date(), icon: String, category: String, time: String) throws -> StatsModel {
@@ -104,5 +97,14 @@ final class SwiftDataManager: TimerRepository {
     } catch {
       throw RepositoryError.saveFailed
     }
+  }
+
+  // MARK: - Helper
+
+  func fetch(by id: UUID) throws -> TimerModel? {
+    let predicate = #Predicate<TimerModel> { $0.timerID == id }
+    var descriptor = FetchDescriptor<TimerModel>(predicate: predicate)
+    descriptor.fetchLimit = 1
+    return try modelContext.fetch(descriptor).first
   }
 }

--- a/PodoIt/Data/SwiftDataManager.swift
+++ b/PodoIt/Data/SwiftDataManager.swift
@@ -88,4 +88,21 @@ final class SwiftDataManager: TimerRepository {
     descriptor.fetchLimit = 1
     return try modelContext.fetch(descriptor).first
   }
+  
+  @discardableResult
+  func insertStats(date: Date = Date(), icon: String, category: String, time: String) throws -> StatsModel {
+    let entity = StatsModel(
+      date: date,
+      icon: icon,
+      category: category,
+      time: time
+    )
+    modelContext.insert(entity)
+    do {
+      try modelContext.save()
+      return entity
+    } catch {
+      throw RepositoryError.saveFailed
+    }
+  }
 }

--- a/PodoIt/Models/StatsModel.swift
+++ b/PodoIt/Models/StatsModel.swift
@@ -11,20 +11,17 @@ import SwiftData
 // Stats 모델
 @Model
 final class StatsModel: Hashable {
-  var statsID: UUID
   var date: Date
   var icon: String
   var category: String
-  var time: Int
+  var time: String
 
   init(
-    statsID: UUID = UUID(),
     date: Date,
     icon: String,
     category: String,
-    time: Int
+    time: String
   ) {
-    self.statsID = statsID
     self.date = date
     self.icon = icon
     self.category = category

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -94,6 +94,7 @@ final class TimerRunViewModel {
   }
   
   /// 정지
+  @MainActor
   func stop() {
     let now = Date()
     let lastTime = Int(now.timeIntervalSince(state.stateStart))
@@ -104,38 +105,32 @@ final class TimerRunViewModel {
       // 혹시 필요할까 싶어서 총 휴식 시간도 누적계산
       state.restSeconds += lastTime
     }
-    
-    /*
-     
-     Models/StateModel의 StatsModel에 저장해야 하는 테이터들
-     var statsID: UUID
-     var date: Date
-     var icon: String
-     var category: String
-     var time: Int
-     
-     */
-    
-    // TODO: 저장 (여기서는 임시로 print로 대체). 추후 SwiftData 저장으로 변경
- 
-    print("""
-      
-      UUID: \(timer?.timerID ?? self.timerID)
-      저장 기준 날짜(stop 버튼 tap한 UTC 기준): \(now)
-      앱 아이콘: \(timer?.iconName ?? "아이콘 이름 없네요")
-      제목/카테고리 이름: \(timer?.title ?? "카테고리명이 왜 없지")
-      목표 공부 시간: \(timer?.goalTime ?? 0)분
-      총 공부한 시간: \(state.studySeconds)초
-      총 공부 시간 format 적용: \(TimerRunViewModel.format(seconds: state.studySeconds))
-      
-      (혹시 몰라서 넣은)
-      총 휴식 시간: \(state.restSeconds)초
-      총 휴식 시간 format 적용: \(TimerRunViewModel.format(seconds: state.restSeconds))
-      """
-    )
+    save()
   }
-    
-  // TODO: makeRunningTimeText, makeGoalTimeText, makeProgress의 중복 코드 리팩토링 예정
+  
+  /// SwiftData의 StatsModel에 데이터 저장
+  @MainActor
+  private func save() {
+    guard let timer = self.timer else {
+      print("세이브 실패. 타이머 데이터가 없습니다.")
+      return
+    }
+    do {
+      try SwiftDataManager.shared.insertStats(
+        icon: timer.iconName, // 타이머 아이콘
+        category: timer.title, // 타이머 이름
+        time: TimerRunViewModel.format(seconds: state.studySeconds) // 총 공부 시간
+      )
+      print("""
+        [데이터 저장 완료]
+        아이콘 이름: \(timer.iconName)
+        타이머 이름: \(timer.title)
+        총 공부 시간: \(TimerRunViewModel.format(seconds: state.studySeconds))
+        """)
+    } catch {
+      print("데이터 저장 실패: \(RepositoryError.saveFailed)")
+    }
+  }
 
   // MARK: Stream
 


### PR DESCRIPTION
## 🔗 관련 이슈

- #48 

## 🔧 PR 요약
- StatsModel에서 사용하지 않는 UUID 삭제 및 time 타입을 Int에서 String으로 변경
- StatsModel 엔티티를 생성하고 저장하는 기능 구현
- stop() 실행 시 save()메서드를 불러와서 SwiftData의 StatsModel에 공부 시간, 아이콘, 카테고리 저장
  - 저장 성공/실패 여부를 print 로그로 출력
  - timer 데이터가 없을 경우 저장 시도 방지 처리

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/a11521f0-563e-48eb-be6a-8560b40255a7

## 📎 기타 참고사항

> 추가적으로 논의하고 싶은 내용이 있다면 작성해주세요.
