### PR TITLE
feat: #91 - 공부/휴식 상태 progress와 buttons 스위칭 UI 구현

### DIFF
--- a/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
@@ -13,7 +13,13 @@ final class MiddleSectionView: UIView {
   // progressBar / restTimerButton을 번갈아가며 isHidden처리 예정
   // progressBar은 top.bottom = 16, restTimerButton은 top.bottom = 12
   // 토글 될 때마다 위 아래 여백을 미리 만들어두고 토글되서 바꾸는 식으로 해야할 듯 싶음
-  private let switchContainerView = UIView()
+  private let switchVStackView = UIStackView().then { // progressView, restButtonsView를 감싼 스택뷰
+    $0.axis = .vertical
+  }
+  
+  private let progressView = UIView() // progressBar를 감싸는 View (isHidden 대상)
+  
+  private let restButtonsView = UIView() // restButtons를 감싸는 View (isHidden 대상)
 
   private let progressContainer = UIView().then { // 진행률 바 배경 View
     $0.backgroundColor = .primary50
@@ -41,17 +47,27 @@ final class MiddleSectionView: UIView {
   // MARK: - configureUI
 
   private func configureUI() {
-    addSubview(switchContainerView)
-    switchContainerView.addSubview(progressContainer)
+    addSubview(switchVStackView)
+    [progressView, restButtonsView].forEach { switchVStackView.addArrangedSubview($0) }
+    progressView.addSubview(progressContainer)
     progressContainer.addSubview(progressBar)
   }
 
   // MARK: - configureLayout
 
   private func configureLayout() {
-    switchContainerView.snp.makeConstraints {
-      $0.top.bottom.equalToSuperview().inset(16)
+    switchVStackView.snp.makeConstraints {
+      $0.top.bottom.equalToSuperview()
+      $0.height.equalTo(64)
       $0.leading.trailing.equalToSuperview().inset(20)
+    }
+    
+    progressView.snp.makeConstraints {
+      $0.height.equalTo(32)
+    }
+    
+    restButtonsView.snp.makeConstraints {
+      $0.height.equalTo(40)
     }
 
     progressContainer.snp.makeConstraints {

--- a/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
@@ -10,14 +10,14 @@ import Then
 import UIKit
 
 final class MiddleSectionView: UIView {
-  // progressBar / restTimerButton을 번갈아가며 isHidden처리 예정
-  // progressBar은 top.bottom = 16, restTimerButton은 top.bottom = 12
-  // 토글 될 때마다 위 아래 여백을 미리 만들어두고 토글되서 바꾸는 식으로 해야할 듯 싶음
+  // MARK: Components
+
   private let switchContainerView = UIView() // progressView, restButtonsView를 감싼 스택뷰
   
-  private let progressView = UIView() // progressBar를 감싸는 View (isHidden 대상)
-  
-  private let restButtonsView = UIView() // restButtons를 감싸는 View (isHidden 대상)
+  // progress
+  private let progressView = UIView().then { // progressBar를 감싸는 View (isHidden 대상)
+    $0.isHidden = false
+  }
 
   private let progressContainer = UIView().then { // 진행률 바 배경 View
     $0.backgroundColor = .primary50
@@ -30,6 +30,35 @@ final class MiddleSectionView: UIView {
     $0.layer.cornerRadius = 12
     $0.clipsToBounds = true
   }
+  
+  // buttons
+  private let restButtonsView = UIView().then { // restButtons를 감싸는 View (isHidden 대상)
+    $0.isHidden = true
+  }
+  private let buttonsHStackView = UIStackView().then { // 3개 버튼의 H스택뷰
+    $0.axis = .horizontal
+    $0.alignment = .center
+    $0.distribution = .equalSpacing
+    $0.spacing = 8
+  }
+  
+  private let plusOneMinuteButton = UIButton(type: .system).then { // +1분
+    $0.setTitle("+1분", for: .normal)
+  }
+  private let plusFiveMinuteButton = UIButton(type: .system).then { // +5분
+    $0.setTitle("+5분", for: .normal)
+  }
+  private let plusTenMinuteButton = UIButton(type: .system).then { // +10분
+    $0.setTitle("+10분", for: .normal)
+  }
+  
+  private lazy var restAddButtons: [UIButton] = [ // 버튼들 공통 로직 쓰기 편하도록 묶음
+    plusOneMinuteButton,
+    plusFiveMinuteButton,
+    plusTenMinuteButton,
+  ]
+  
+  // MARK: - init
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -49,6 +78,14 @@ final class MiddleSectionView: UIView {
     [progressView, restButtonsView].forEach { switchContainerView.addSubview($0) }
     progressView.addSubview(progressContainer)
     progressContainer.addSubview(progressBar)
+    restButtonsView.addSubview(buttonsHStackView)
+    restAddButtons.forEach { buttonsHStackView.addArrangedSubview($0) }
+    
+    restAddButtons.forEach {
+      $0.backgroundColor = .gray100
+      $0.titleLabel?.font = Typography.font(for: .labelLg(weight: .semibold))
+      $0.setTitleColor(.gray900, for: .normal)
+    }
   }
 
   // MARK: - configureLayout
@@ -63,11 +100,6 @@ final class MiddleSectionView: UIView {
       $0.top.bottom.equalToSuperview().inset(16)
       $0.leading.trailing.equalToSuperview()
     }
-    
-    restButtonsView.snp.makeConstraints {
-      $0.top.bottom.equalToSuperview().inset(12)
-      $0.leading.trailing.equalToSuperview()
-    }
 
     progressContainer.snp.makeConstraints {
       $0.directionalEdges.equalToSuperview()
@@ -78,6 +110,15 @@ final class MiddleSectionView: UIView {
       $0.centerY.equalToSuperview()
       $0.leading.trailing.equalToSuperview().inset(4)
       $0.height.equalTo(24)
+    }
+    
+    restButtonsView.snp.makeConstraints {
+      $0.top.bottom.equalToSuperview().inset(12)
+      $0.leading.trailing.equalToSuperview()
+    }
+    
+    buttonsHStackView.snp.makeConstraints {
+      $0.directionalEdges.equalToSuperview()
     }
   }
 

--- a/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
@@ -16,7 +16,7 @@ final class MiddleSectionView: UIView {
   
   // progress
   private let progressView = UIView().then { // progressBar를 감싸는 View (isHidden 대상)
-    $0.isHidden = false
+    $0.isHidden = true
   }
 
   private let progressContainer = UIView().then { // 진행률 바 배경 View
@@ -33,7 +33,7 @@ final class MiddleSectionView: UIView {
   
   // buttons
   private let restButtonsView = UIView().then { // restButtons를 감싸는 View (isHidden 대상)
-    $0.isHidden = true
+    $0.isHidden = false
   }
   private let buttonsHStackView = UIStackView().then { // 3개 버튼의 H스택뷰
     $0.axis = .horizontal
@@ -85,6 +85,7 @@ final class MiddleSectionView: UIView {
       $0.backgroundColor = .gray100
       $0.titleLabel?.font = Typography.font(for: .labelLg(weight: .semibold))
       $0.setTitleColor(.gray900, for: .normal)
+      $0.layer.cornerRadius = 8
     }
   }
 
@@ -118,7 +119,15 @@ final class MiddleSectionView: UIView {
     }
     
     buttonsHStackView.snp.makeConstraints {
-      $0.directionalEdges.equalToSuperview()
+      $0.centerX.equalToSuperview()
+      $0.top.bottom.equalToSuperview()
+    }
+    
+    restAddButtons.forEach {
+      $0.snp.makeConstraints {
+        $0.width.equalTo(72)
+        $0.height.equalTo(44) // TODO: 44 주고싶어요.. 디자이너님과 대화
+      }
     }
   }
 
@@ -127,5 +136,16 @@ final class MiddleSectionView: UIView {
   func updateProgressBar(progress: Float) {
     progressBar.setProgress(progress, animated: false)
     progressBar.progressTintColor = .primary600
+  }
+  
+  // MARK: - isHidden Update
+  func updateIsHiddenView(isRunning: Bool) {
+    if isRunning { // 공부 중
+      progressView.isHidden = false
+      restButtonsView.isHidden = true
+    } else { // 휴식 중
+      progressView.isHidden = true
+      restButtonsView.isHidden = false
+    }
   }
 }

--- a/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
@@ -13,9 +13,7 @@ final class MiddleSectionView: UIView {
   // progressBar / restTimerButton을 번갈아가며 isHidden처리 예정
   // progressBar은 top.bottom = 16, restTimerButton은 top.bottom = 12
   // 토글 될 때마다 위 아래 여백을 미리 만들어두고 토글되서 바꾸는 식으로 해야할 듯 싶음
-  private let switchVStackView = UIStackView().then { // progressView, restButtonsView를 감싼 스택뷰
-    $0.axis = .vertical
-  }
+  private let switchContainerView = UIView() // progressView, restButtonsView를 감싼 스택뷰
   
   private let progressView = UIView() // progressBar를 감싸는 View (isHidden 대상)
   
@@ -47,8 +45,8 @@ final class MiddleSectionView: UIView {
   // MARK: - configureUI
 
   private func configureUI() {
-    addSubview(switchVStackView)
-    [progressView, restButtonsView].forEach { switchVStackView.addArrangedSubview($0) }
+    addSubview(switchContainerView)
+    [progressView, restButtonsView].forEach { switchContainerView.addSubview($0) }
     progressView.addSubview(progressContainer)
     progressContainer.addSubview(progressBar)
   }
@@ -56,18 +54,19 @@ final class MiddleSectionView: UIView {
   // MARK: - configureLayout
 
   private func configureLayout() {
-    switchVStackView.snp.makeConstraints {
+    switchContainerView.snp.makeConstraints {
       $0.top.bottom.equalToSuperview()
-      $0.height.equalTo(64)
       $0.leading.trailing.equalToSuperview().inset(20)
     }
     
     progressView.snp.makeConstraints {
-      $0.height.equalTo(32)
+      $0.top.bottom.equalToSuperview().inset(16)
+      $0.leading.trailing.equalToSuperview()
     }
     
     restButtonsView.snp.makeConstraints {
-      $0.height.equalTo(40)
+      $0.top.bottom.equalToSuperview().inset(12)
+      $0.leading.trailing.equalToSuperview()
     }
 
     progressContainer.snp.makeConstraints {

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -138,6 +138,7 @@ final class TimerRunViewController: UIViewController {
         let (isRunning, goalTime, restTime, runningTime) = data
         // 공부/휴식 중 상태에 따른 버튼 UI 업데이트
         vc.buttonBarView.updateStartPauseButtonImage(isRunning: isRunning)
+        vc.middleView.updateIsHiddenView(isRunning: isRunning)
 
         if isRunning { // 공부중
           vc.timerView.updateGoalTimeUI(goalTime: goalTime, runningTime: runningTime)

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -105,21 +105,6 @@ final class TimerRunViewController: UIViewController {
       }
       .disposed(by: disposeBag)
 
-    // isRunning 상태에 따라 runningTimeText(공부 타이머) 또는 restTimeText(휴식 타이머) 스트림 선택
-//    let timerTextStream: Driver<String> = viewModel.isRunningDriver
-//      .flatMapLatest { [weak self] isRunning in // 중첩을 펴서 최신의 Driver만 유지
-//        guard let self else { return Driver.just("00:00") }
-//        // 공부중이면 공부 시간 타이머, 휴식중이면 휴식 시간 타이머를 실행
-//        return isRunning ? self.viewModel.runningTimeText : self.viewModel.restTimeText
-//      }
-
-//    timerTextStream // runningTimeText(공부 타이머) 또는 restTimeText(휴식 타이머) 스트림
-//      .asObservable() // .take(until:)가 Observable 연산자라서 변경
-//      .take(until: rx.methodInvoked(#selector(UIViewController.viewWillDisappear(_:))))
-//      .asDriver(onErrorJustReturn: "00:00")
-//      .drive(timerView.activeTimerLabel.rx.text)
-//      .disposed(by: disposeBag)
-
     // progressBar 진행
     viewModel.progress
       .asObservable()


### PR DESCRIPTION
## 🔗 관련 이슈

- #91 

## 🔧 PR 요약
- 휴식 버튼(+1, +5, +10분) 3개 생성 및 중앙 정렬 제약 추가
- progressView / restButtonsView의 isHidden 토글 로직 추가
- 공부/휴식 상태 전환 시 UI가 자연스럽게 변경되도록 처리

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/7d21f63f-2e85-43f8-b279-14a1a8555716

## 📎 기타 참고사항
- UI를 우선적으로 하려고 하여 버튼 누를 때 시간이 추가되는건 추후에  구현할 예정입니다.
