### PR TITLE
feat: #99 - 휴식 상태의 총 휴식시간 데이터 수정

### DIFF
--- a/PodoIt/Scenes/TimerRun/View/Sections/TimerSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/TimerSectionView.swift
@@ -115,7 +115,7 @@ final class TimerSectionView: UIView {
   }
 
   /// 휴식 중. 휴식시간이 끝나는것을 기준으로 UI 업데이트
-  func updateRestTimeUI(restTime: String) {
+  func updateRestTimeUI(restTime: String, totalRestTime: String) {
     sessionIconImageView.image = UIImage(named: "cup")
     if restTime == "00:00" { // 휴식 시간이 끝났을 경우
       activeTimerLabel.text = "휴식 시간이 끝났어요"
@@ -126,10 +126,7 @@ final class TimerSectionView: UIView {
     } else { // 휴식 시간이 남아있을 경우
       activeTimerLabel.text = restTime
       activeTimerLabel.font = Typography.font(for: .displayLg(weight: .bold)).monospacedDigits()
-      
-      // TODO: 총 휴식 시간을 바인딩해주어야함
-//      sessionTimeLabel.text = ?
-      
+      sessionTimeLabel.text = totalRestTime
       sessionContainerView.backgroundColor = .green100
       sessionIconImageView.tintColor = .green600
       sessionTimeLabel.textColor = .green600

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -129,13 +129,14 @@ final class TimerRunViewController: UIViewController {
     // 공부/휴식 상태에 따라서 목표시간 또는 휴식시간 UI를 업데이트
     // 여러개의 Driver 스트림을 합쳐서 하나로 만들어줌
     Driver.combineLatest(
-      viewModel.isRunningDriver,
-      viewModel.goalTimeText,
-      viewModel.restTimeText,
-      viewModel.runningTimeText
+      viewModel.isRunningDriver, // 공부/휴식 중 상태 (Bool)
+      viewModel.goalTimeText, // 공부 목표시간 (MM:SS)
+      viewModel.totalRestTimeText, // 총 "휴식 중인 시간" (MM:SS)
+      viewModel.restTimeText, // "남은 휴식시간" (기본 5분. MM:SS)
+      viewModel.runningTimeText // 공부중인 시간 (H:MM:SS)
     )
       .drive(with: self) { vc, data in
-        let (isRunning, goalTime, restTime, runningTime) = data
+        let (isRunning, goalTime, totalRestTime, restTime, runningTime) = data
         // 공부/휴식 중 상태에 따른 버튼 UI 업데이트
         vc.buttonBarView.updateStartPauseButtonImage(isRunning: isRunning)
         vc.middleView.updateIsHiddenView(isRunning: isRunning)
@@ -143,7 +144,7 @@ final class TimerRunViewController: UIViewController {
         if isRunning { // 공부중
           vc.timerView.updateGoalTimeUI(goalTime: goalTime, runningTime: runningTime)
         } else { // 휴식중
-          vc.timerView.updateRestTimeUI(restTime: restTime)
+          vc.timerView.updateRestTimeUI(restTime: restTime, totalRestTime: totalRestTime)
         }
       }
       .disposed(by: disposeBag)

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -49,8 +49,10 @@ final class TimerRunViewModel {
   
   lazy var goalTimeText: Driver<String> = makeGoalTimeText(tick: tick) // 공부 목표시간 (MM:SS)
   lazy var runningTimeText: Driver<String> = makeRunningTimeText(tick: tick) // 공부중인 시간 (H:MM:SS)
-//  lazy var  // 총 휴식중인 시간
-  lazy var restTimeText: Driver<String> = makeRestTimeText(tick: tick) // 남은 휴식시간 방출 (기본 5분. MM:SS)
+
+  lazy var totalRestTimeText: Driver<String> = makeTotalRestTimeText(tick: tick) // 총 "휴식 중인 시간"
+  lazy var restTimeText: Driver<String> = makeRestTimeText(tick: tick) // "남은 휴식시간" 방출 (기본 5분. MM:SS)
+
   lazy var progress: Driver<Float> = makeProgress(tick: tick) // progress 진행률 방출
   
   // MARK: - init
@@ -163,16 +165,30 @@ final class TimerRunViewModel {
       .asDriver(onErrorJustReturn: "0:00:00") // 에러나면 기본으로 "0:00:00" 방출
   }
   
-  /// UI의 라벨에 바인딩할 휴식시간 문자열 Driver 생성
+  // MARK: - makeRestTimeText, makeTotalRestTimeText 중복 로직 리팩토링 예정
+  /// UI의 라벨에 바인딩할 "남은 휴식 시간" 문자열 Driver 생성
   private func makeRestTimeText(tick: Observable<Int>) -> Driver<String> {
     return tick.withUnretained(self)
       .map { vm, _ in // 300초 - 휴식시간, 0
         let now = Date()
-        let elaspedRestTime = vm.state.isRunning ? 0 : Int(now.timeIntervalSince(vm.state.stateStart)) // 이번 세션에 실시간으로 휴식중인 시간 (공부중인 시간 제외)
+        let elapsedRestTime = vm.state.isRunning ? 0 : Int(now.timeIntervalSince(vm.state.stateStart)) // 이번 세션에 실시간으로 휴식중인 시간 (공부중인 시간 제외)
         // 매 섹션마다 휴식시간 5분으로 초기화
         // 300초(기본 값) - 이번 세션에 휴식중인 시간 (음수라면 0으로 max)
-        let remainingRestTime = max(vm.defaultRestSeconds - elaspedRestTime, 0)
+        let remainingRestTime = max(vm.defaultRestSeconds - elapsedRestTime, 0)
         return TimerRunViewModel.formatMMSS(seconds: remainingRestTime)
+      }
+      .distinctUntilChanged()
+      .asDriver(onErrorJustReturn: "00:00")
+  }
+  
+  /// UI의 라벨에 바인딩할 "총 휴식중인 시간" 문자열 Driver 생성
+  private func makeTotalRestTimeText(tick: Observable<Int>) -> Driver<String> {
+    return tick.withUnretained(self)
+      .map { vm, _ in // now(현재) - stateStart(휴식 섹션 시작한 시간)
+        let now = Date()
+        let elapsedRestTime = vm.state.isRunning ? 0 : Int(now.timeIntervalSince(vm.state.stateStart))
+        let totalRestTime = min(elapsedRestTime, 1800) // 쉬는 시간 최대 30분(1800초)
+        return TimerRunViewModel.formatMMSS(seconds: totalRestTime)
       }
       .distinctUntilChanged()
       .asDriver(onErrorJustReturn: "00:00")


### PR DESCRIPTION
## 🔗 관련 이슈

- #99 

## 🔧 PR 요약
- TimerRunViewController에서 combineLatest 바인딩 시 totalRestTime 전달
- TimerSectionView.updateRestTimeUI()에 totalRestTime 파라미터 추가
- sessionTimeLabel.text에 totalRestTime 표시하도록 수정

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

> 목표시간 달성 및 휴식시간 5분 타이머

https://github.com/user-attachments/assets/5cf69cd2-47a0-428f-8dde-056f5c7c6af8

> 휴식 시간이 끝난 UI로 전환 및 휴식 재시작 시 5분 타이머가 다시 동작

https://github.com/user-attachments/assets/58706013-782d-4794-a7d6-f78881becab1

## 📎 기타 참고사항
- 여전히 버튼으로 시간 추가는 안됩니다. UI 우선적으로 다 했습니다.
