### PR TITLE
feat: #100 -통계 화면 집중 시간 데이터 없을때 View 변경

### DIFF
--- a/PodoIt/Scenes/Stats/View/StatsViewController.swift
+++ b/PodoIt/Scenes/Stats/View/StatsViewController.swift
@@ -103,11 +103,18 @@ final class StatsViewController: UIViewController {
       .disposed(by: disposeBag)
 
     // VM → SummaryView 반영
-    viewModel.summary
-      .drive(onNext: { [weak self] ui in
-        self?.summaryView.apply(items: ui.items, totalTimeText: ui.totalText)
-      })
-      .disposed(by: disposeBag)
+    Driver.combineLatest(
+      viewModel.summary, // SummaryUI(items, totalText)
+      viewModel.selectedSegmentIndex.asDriver() // 0=일간, 1=월간
+    )
+    .drive(onNext: { [weak self] ui, seg in
+      self?.summaryView.apply(
+        items: ui.items,
+        totalTimeText: ui.totalText,
+        isDaily: seg == 0
+      )
+    })
+    .disposed(by: disposeBag)
   }
 
   // MARK: - CategorySheet Presentation

--- a/PodoIt/Scenes/Stats/View/ViewSubClasses/Summary/StatsSummaryView.swift
+++ b/PodoIt/Scenes/Stats/View/ViewSubClasses/Summary/StatsSummaryView.swift
@@ -39,6 +39,20 @@ final class StatsSummaryView: UIView {
   }
 
   private let segmentedControl = StatsCustomSegmentedControl(items: ["일간", "월간"])
+  
+  private let emptyView = UIView().then {
+    $0.backgroundColor = .appWhite
+    $0.isHidden = true
+  }
+  
+  private let emptyLabel = UILabel().then {
+    $0.textAlignment = .center
+    $0.numberOfLines = 0
+    $0.text = "이 날에는 기록된\n집중 시간이 없어요."
+    $0.font = Typography.font(for: .bodyLg(weight: .regular))
+    $0.textColor = .gray400
+    $0.lineBreakMode = .byWordWrapping
+  }
 
   private let totalTimeTotalLabel = UILabel.makeAttributed(
     text: "총", style: .headingMd, color: .gray500, alignment: .left
@@ -102,7 +116,7 @@ final class StatsSummaryView: UIView {
   // 높이를 제약할 변수
   private var collectionViewHeightConstraint: Constraint?
 
-  private lazy var vStack = UIStackView(arrangedSubviews: [segmentedControl, totalTimeStackView, collectionView]).then {
+  private lazy var vStack = UIStackView(arrangedSubviews: [segmentedControl, emptyView, totalTimeStackView, collectionView]).then {
     $0.axis = .vertical
     $0.alignment = .center
     $0.spacing = 16
@@ -149,6 +163,7 @@ final class StatsSummaryView: UIView {
     [container].forEach { addSubview($0) }
     [summaryContainer].forEach { container.contentView.addSubview($0) }
     [vStack].forEach { summaryContainer.contentView.addSubview($0) }
+    emptyView.addSubview(emptyLabel)
   }
 
   private func setupConstraints() {
@@ -168,6 +183,15 @@ final class StatsSummaryView: UIView {
       // 초기값 0으로 설정, 나중에 계산해서 업데이트
       collectionViewHeightConstraint = $0.height.equalTo(0).constraint
       $0.directionalHorizontalEdges.equalToSuperview()
+    }
+    
+    emptyView.snp.makeConstraints {
+      $0.height.equalTo(106)
+      $0.directionalHorizontalEdges.equalToSuperview()
+    }
+    
+    emptyLabel.snp.makeConstraints {
+      $0.center.equalToSuperview()
     }
   }
 
@@ -199,15 +223,37 @@ final class StatsSummaryView: UIView {
   }
 
   // 외부에서 리스트/총합 주입
-  func apply(items: [StatsSummaryModel], totalTimeText: String) {
+  func apply(items: [StatsSummaryModel], totalTimeText: String, isDaily: Bool) {
+    // 합계 텍스트
     totalTimeLabel.text = totalTimeText
 
+    // 리스트 스냅샷
     var snapshot = NSDiffableDataSourceSnapshot<Int, StatsSummaryModel>()
     snapshot.appendSections([0])
     snapshot.appendItems(items)
     dataSource.apply(snapshot, animatingDifferences: false)
 
+    // 컬렉션뷰 높이 갱신
     updateCollectionViewHeight(itemCount: items.count)
+
+    // 보여줄 섹션 토글
+    let hasData = !items.isEmpty
+    totalTimeStackView.isHidden = !hasData
+    collectionView.isHidden = !hasData
+    emptyView.isHidden = hasData
+
+    // empty 라벨 텍스트/폰트 토글
+    if !hasData {
+      if isDaily {
+        // 일간
+        emptyLabel.text = "이 날에는 기록된\n집중 시간이 없어요."
+        emptyLabel.font = Typography.font(for: .bodyLg(weight: .regular))
+      } else {
+        // 월간
+        emptyLabel.text = "이 달에는 기록된\n집중 시간이 없어요."
+        emptyLabel.font = Typography.font(for: .bodyLg(weight: .semibold))
+      }
+    }
   }
 
   // MARK: - Bind


### PR DESCRIPTION
## 🔗 관련 이슈

- #100 

## 🔧 PR 요약

- 통계 화면 집중 시간 데이터 없을때 View 변경

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷

https://github.com/user-attachments/assets/db6ca7ea-3d9e-4112-b026-96971b1e580c