### PR TITLE
feat: #106 - 휴식시간 추가 기능 구현

### DIFF
--- a/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
@@ -5,6 +5,7 @@
 //  Created by 서광용 on 8/28/25.
 //
 
+import RxCocoa
 import SnapKit
 import Then
 import UIKit
@@ -13,7 +14,7 @@ final class MiddleSectionView: UIView {
   // MARK: Components
 
   private let switchContainerView = UIView() // progressView, restButtonsView를 감싼 스택뷰
-  
+
   // progress
   private let progressView = UIView().then { // progressBar를 감싸는 View (isHidden 대상)
     $0.isHidden = true
@@ -30,34 +31,37 @@ final class MiddleSectionView: UIView {
     $0.layer.cornerRadius = 12
     $0.clipsToBounds = true
   }
-  
+
   // buttons
   private let restButtonsView = UIView().then { // restButtons를 감싸는 View (isHidden 대상)
     $0.isHidden = false
   }
+
   private let buttonsHStackView = UIStackView().then { // 3개 버튼의 H스택뷰
     $0.axis = .horizontal
     $0.alignment = .center
     $0.distribution = .equalSpacing
     $0.spacing = 8
   }
-  
+
   private let plusOneMinuteButton = UIButton(type: .system).then { // +1분
     $0.setTitle("+1분", for: .normal)
   }
+
   private let plusFiveMinuteButton = UIButton(type: .system).then { // +5분
     $0.setTitle("+5분", for: .normal)
   }
+
   private let plusTenMinuteButton = UIButton(type: .system).then { // +10분
     $0.setTitle("+10분", for: .normal)
   }
-  
+
   private lazy var restAddButtons: [UIButton] = [ // 버튼들 공통 로직 쓰기 편하도록 묶음
     plusOneMinuteButton,
     plusFiveMinuteButton,
     plusTenMinuteButton,
   ]
-  
+
   // MARK: - init
 
   override init(frame: CGRect) {
@@ -80,12 +84,12 @@ final class MiddleSectionView: UIView {
     progressContainer.addSubview(progressBar)
     restButtonsView.addSubview(buttonsHStackView)
     restAddButtons.forEach { buttonsHStackView.addArrangedSubview($0) }
-    
-    restAddButtons.forEach {
-      $0.backgroundColor = .gray100
-      $0.titleLabel?.font = Typography.font(for: .labelLg(weight: .semibold))
-      $0.setTitleColor(.gray900, for: .normal)
-      $0.layer.cornerRadius = 8
+
+    for restAddButton in restAddButtons {
+      restAddButton.backgroundColor = .gray100
+      restAddButton.titleLabel?.font = Typography.font(for: .labelLg(weight: .semibold))
+      restAddButton.setTitleColor(.gray900, for: .normal)
+      restAddButton.layer.cornerRadius = 8
     }
   }
 
@@ -96,7 +100,7 @@ final class MiddleSectionView: UIView {
       $0.top.bottom.equalToSuperview()
       $0.leading.trailing.equalToSuperview().inset(20)
     }
-    
+
     progressView.snp.makeConstraints {
       $0.top.bottom.equalToSuperview().inset(16)
       $0.leading.trailing.equalToSuperview()
@@ -112,19 +116,19 @@ final class MiddleSectionView: UIView {
       $0.leading.trailing.equalToSuperview().inset(4)
       $0.height.equalTo(24)
     }
-    
+
     restButtonsView.snp.makeConstraints {
       $0.top.bottom.equalToSuperview().inset(12)
       $0.leading.trailing.equalToSuperview()
     }
-    
+
     buttonsHStackView.snp.makeConstraints {
       $0.centerX.equalToSuperview()
       $0.top.bottom.equalToSuperview()
     }
-    
-    restAddButtons.forEach {
-      $0.snp.makeConstraints {
+
+    for restAddButton in restAddButtons {
+      restAddButton.snp.makeConstraints {
         $0.width.equalTo(72)
         $0.height.equalTo(44)
       }
@@ -137,8 +141,9 @@ final class MiddleSectionView: UIView {
     progressBar.setProgress(progress, animated: false)
     progressBar.progressTintColor = .primary600
   }
-  
+
   // MARK: - isHidden Update
+
   func updateIsHiddenView(isRunning: Bool) {
     if isRunning { // 공부 중
       progressView.isHidden = false
@@ -147,5 +152,19 @@ final class MiddleSectionView: UIView {
       progressView.isHidden = true
       restButtonsView.isHidden = false
     }
+  }
+}
+
+extension MiddleSectionView {
+  var plusOneMinuteButtonTap: ControlEvent<Void> { // +1분
+    return plusOneMinuteButton.rx.tap
+  }
+
+  var plusFiveMinuteButtonTap: ControlEvent<Void> { // +5분
+    return plusFiveMinuteButton.rx.tap
+  }
+
+  var plusTenMinuteButtonTap: ControlEvent<Void> { // +10분
+    return plusTenMinuteButton.rx.tap
   }
 }

--- a/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/MiddleSectionView.swift
@@ -126,7 +126,7 @@ final class MiddleSectionView: UIView {
     restAddButtons.forEach {
       $0.snp.makeConstraints {
         $0.width.equalTo(72)
-        $0.height.equalTo(44) // TODO: 44 주고싶어요.. 디자이너님과 대화
+        $0.height.equalTo(44)
       }
     }
   }

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -87,6 +87,21 @@ final class TimerRunViewController: UIViewController {
 
   /// Rx 바인딩 설정 (버튼 탭, 진행률 등)
   private func bind() {
+    let addOne = middleView.plusOneMinuteButtonTap.asSignal().map { RestAddCase.one }
+    let addFive = middleView.plusFiveMinuteButtonTap.asSignal().map { RestAddCase.five }
+    let addTen = middleView.plusTenMinuteButtonTap.asSignal().map { RestAddCase.ten }
+
+    // 세 스트림을 하나로 합침
+    let restAddSignal = Signal.merge(addOne, addFive, addTen)
+
+    // restAddSignal이 "어떤 버튼이 눌렸는지"를 인식해서 값을 반환
+    restAddSignal
+      .withUnretained(self)
+      .emit(onNext: { vc, addTime in
+        vc.viewModel.restAddSeconds += addTime.seconds // 반한된 값(60, 300, 600초)을 할당함
+      })
+      .disposed(by: disposeBag)
+
     // 버튼 Tap을 스트림으로 받아서 viewModel의 토글 실행 (start/pause)
     buttonBarView.startPauseTap
       .asDriver()
@@ -125,9 +140,8 @@ final class TimerRunViewController: UIViewController {
       }
       .disposed(by: disposeBag)
 
-    // TODO: restTimeText 아님. 데이터 이거 아니야
     // 공부/휴식 상태에 따라서 목표시간 또는 휴식시간 UI를 업데이트
-    // 여러개의 Driver 스트림을 합쳐서 하나로 만들어줌
+    // combineLatest: 여러개의 Driver 스트림을 합쳐서 하나로 만들어줌
     Driver.combineLatest(
       viewModel.isRunningDriver, // 공부/휴식 중 상태 (Bool)
       viewModel.goalTimeText, // 공부 목표시간 (MM:SS)
@@ -135,19 +149,19 @@ final class TimerRunViewController: UIViewController {
       viewModel.restTimeText, // "남은 휴식시간" (기본 5분. MM:SS)
       viewModel.runningTimeText // 공부중인 시간 (H:MM:SS)
     )
-      .drive(with: self) { vc, data in
-        let (isRunning, goalTime, totalRestTime, restTime, runningTime) = data
-        // 공부/휴식 중 상태에 따른 버튼 UI 업데이트
-        vc.buttonBarView.updateStartPauseButtonImage(isRunning: isRunning)
-        vc.middleView.updateIsHiddenView(isRunning: isRunning)
+    .drive(with: self) { vc, data in
+      let (isRunning, goalTime, totalRestTime, restTime, runningTime) = data
+      // 공부/휴식 중 상태에 따른 버튼 UI 업데이트
+      vc.buttonBarView.updateStartPauseButtonImage(isRunning: isRunning)
+      vc.middleView.updateIsHiddenView(isRunning: isRunning)
 
-        if isRunning { // 공부중
-          vc.timerView.updateGoalTimeUI(goalTime: goalTime, runningTime: runningTime)
-        } else { // 휴식중
-          vc.timerView.updateRestTimeUI(restTime: restTime, totalRestTime: totalRestTime)
-        }
+      if isRunning { // 공부중
+        vc.timerView.updateGoalTimeUI(goalTime: goalTime, runningTime: runningTime)
+      } else { // 휴식중
+        vc.timerView.updateRestTimeUI(restTime: restTime, totalRestTime: totalRestTime)
       }
-      .disposed(by: disposeBag)
+    }
+    .disposed(by: disposeBag)
   }
 
   // MARK: UI Configuration

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -98,7 +98,7 @@ final class TimerRunViewController: UIViewController {
     restAddSignal
       .withUnretained(self)
       .emit(onNext: { vc, addTime in
-        vc.viewModel.restAddSeconds += addTime.seconds // 반한된 값(60, 300, 600초)을 할당함
+        vc.viewModel.addRestTime(seconds: addTime.seconds) // 반한된 값(60, 300, 600초)을 할당함
       })
       .disposed(by: disposeBag)
 

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -51,6 +51,7 @@ final class TimerRunViewModel {
   // 목표시간 (초). load()시에 분 -> 초 단위로 세팅됨
   private(set) var goalTime: Int = 0
   private var defaultRestSeconds: Int = 300 // 기본 휴식시간 5분 고정 (매 휴식마다 5분 초기화)
+  private let restTimeLimit = 1800 // 휴식시간 최대 1800초 제한
   var restAddSeconds = 0 // 기본 휴식시간에 추가로 더 휴식하는 시간
   // 버튼/상태 변화시에 즉시 재계산을 위함
   private let restUpdateRelay = PublishRelay<Void>() // 초기값 없이 단순 이벤트 방출
@@ -206,7 +207,7 @@ final class TimerRunViewModel {
         // 매 섹션마다 휴식시간 5분으로 초기화
         // 300초(기본 값) - 이번 세션에 휴식중인 시간 + 추가된 휴식 시간(restAddSeconds), (음수라면 0으로 max)
         let remainingRestTime = max(vm.defaultRestSeconds - elapsedRestTime + vm.restAddSeconds, 0)
-//        let 최대 remainingRestTime이랑 max를 1800초
+        // TODO: 최대 휴식 시간을 30분으로 잡기. (로직이 생각이 전혀 안나서 못막은 상태.. 정 안되면 시간부터 내려가는 식으로..)
         return TimerRunViewModel.formatMMSS(seconds: remainingRestTime)
       }
       .distinctUntilChanged()

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -52,6 +52,8 @@ final class TimerRunViewModel {
   private(set) var goalTime: Int = 0
   private var defaultRestSeconds: Int = 300 // 기본 휴식시간 5분 고정 (매 휴식마다 5분 초기화)
   var restAddSeconds = 0 // 기본 휴식시간에 추가로 더 휴식하는 시간
+  // 버튼/상태 변화시에 즉시 재계산을 위함
+  private let restUpdateRelay = PublishRelay<Void>() // 초기값 없이 단순 이벤트 방출
   
   // MARK: - Tick (공유 타이머 스트림)
   
@@ -60,13 +62,20 @@ final class TimerRunViewModel {
     .startWith(0) // startWith(0)을 안붙여주면, 첫 이벤트가 1초 뒤에 옴.
     .share(replay: 1, scope: .whileConnected) // share로 한 번에 여러곳에 공유. 가장 최근 이벤트 1개 방출 및 구독자가 존재할때만 스트림 유지
   
-  // MARK: - Outputs (UI 바인딩용 Driver)
+  // tick(1초) + 버튼 이벤트를 합쳐서 재계산하는 트리거
+  // 버튼 누를 시 tick(1초)뒤가 아닌 즉시 시간이 재계산되게 하기 위해서
+  private lazy var restTimeUpdateTrigger: Observable<Void> = Observable.merge(
+    tick.map { _ in }, // Observable<Void>로 반환
+    restUpdateRelay.asObservable()
+  )
   
+  // MARK: - Outputs (UI 바인딩용 Driver)
+
   lazy var goalTimeText: Driver<String> = makeGoalTimeText(tick: tick) // 공부 목표시간 (MM:SS)
   lazy var runningTimeText: Driver<String> = makeRunningTimeText(tick: tick) // 공부중인 시간 (H:MM:SS)
 
   lazy var totalRestTimeText: Driver<String> = makeTotalRestTimeText(tick: tick) // 총 "휴식 중인 시간"
-  lazy var restTimeText: Driver<String> = makeRestTimeText(tick: tick) // "남은 휴식시간" 방출 (기본 5분. MM:SS)
+  lazy var restTimeText: Driver<String> = makeRestTimeText(tigger: restTimeUpdateTrigger) // "남은 휴식시간" 방출 (기본 5분. MM:SS)
 
   lazy var progress: Driver<Float> = makeProgress(tick: tick) // progress 진행률 방출
   
@@ -89,6 +98,12 @@ final class TimerRunViewModel {
   }
   
   // MARK: - Actions
+  
+  /// 휴식 시간 추가 (+1/+5/+10) 후 즉시 라벨 갱신
+  func addRestTime(seconds: Int) {
+    restAddSeconds += seconds
+    restUpdateRelay.accept(()) // Void라서 넣지 않고 신호만 보냄
+  }
 
   /// 시작/일시정지 버튼 토글
   func startAndPause() {
@@ -183,14 +198,15 @@ final class TimerRunViewModel {
   // MARK: - makeRestTimeText, makeTotalRestTimeText 중복 로직 리팩토링 예정
 
   /// UI의 라벨에 바인딩할 "남은 휴식 시간" 문자열 Driver 생성
-  private func makeRestTimeText(tick: Observable<Int>) -> Driver<String> {
-    return tick.withUnretained(self)
+  private func makeRestTimeText(tigger: Observable<Void>) -> Driver<String> {
+    return tigger.withUnretained(self)
       .map { vm, _ in // 300초 - 휴식시간, 0
         let now = Date()
         let elapsedRestTime = vm.state.isRunning ? 0 : Int(now.timeIntervalSince(vm.state.stateStart)) // 이번 세션에 실시간으로 휴식중인 시간 (공부중인 시간 제외)
         // 매 섹션마다 휴식시간 5분으로 초기화
         // 300초(기본 값) - 이번 세션에 휴식중인 시간 + 추가된 휴식 시간(restAddSeconds), (음수라면 0으로 max)
         let remainingRestTime = max(vm.defaultRestSeconds - elapsedRestTime + vm.restAddSeconds, 0)
+//        let 최대 remainingRestTime이랑 max를 1800초
         return TimerRunViewModel.formatMMSS(seconds: remainingRestTime)
       }
       .distinctUntilChanged()

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -9,6 +9,20 @@ import Foundation
 import RxCocoa
 import RxSwift
 
+enum RestAddCase {
+  case one
+  case five
+  case ten
+  
+  var seconds: Int {
+    switch self {
+    case .one: return 60
+    case .five: return 300
+    case .ten: return 600
+    }
+  }
+}
+
 final class TimerRunViewModel {
   // MARK: - Dependencies
 
@@ -37,6 +51,7 @@ final class TimerRunViewModel {
   // 목표시간 (초). load()시에 분 -> 초 단위로 세팅됨
   private(set) var goalTime: Int = 0
   private var defaultRestSeconds: Int = 300 // 기본 휴식시간 5분 고정 (매 휴식마다 5분 초기화)
+  var restAddSeconds = 0 // 기본 휴식시간에 추가로 더 휴식하는 시간
   
   // MARK: - Tick (공유 타이머 스트림)
   
@@ -166,6 +181,7 @@ final class TimerRunViewModel {
   }
   
   // MARK: - makeRestTimeText, makeTotalRestTimeText 중복 로직 리팩토링 예정
+
   /// UI의 라벨에 바인딩할 "남은 휴식 시간" 문자열 Driver 생성
   private func makeRestTimeText(tick: Observable<Int>) -> Driver<String> {
     return tick.withUnretained(self)
@@ -173,8 +189,8 @@ final class TimerRunViewModel {
         let now = Date()
         let elapsedRestTime = vm.state.isRunning ? 0 : Int(now.timeIntervalSince(vm.state.stateStart)) // 이번 세션에 실시간으로 휴식중인 시간 (공부중인 시간 제외)
         // 매 섹션마다 휴식시간 5분으로 초기화
-        // 300초(기본 값) - 이번 세션에 휴식중인 시간 (음수라면 0으로 max)
-        let remainingRestTime = max(vm.defaultRestSeconds - elapsedRestTime, 0)
+        // 300초(기본 값) - 이번 세션에 휴식중인 시간 + 추가된 휴식 시간(restAddSeconds), (음수라면 0으로 max)
+        let remainingRestTime = max(vm.defaultRestSeconds - elapsedRestTime + vm.restAddSeconds, 0)
         return TimerRunViewModel.formatMMSS(seconds: remainingRestTime)
       }
       .distinctUntilChanged()


### PR DESCRIPTION
## 🔗 관련 이슈

- #106 

## 🔧 PR 요약

- 휴식 시간 +1/+5/+10 버튼 기능 추가
- 휴식 버튼 누를 시 즉시 재계산해서 1tick을 기다리지 않고 바로 UI에 반영하는 트리거 구현

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/a67bdd58-5a34-424e-83db-efd35d49ae0e

## 📎 기타 참고사항
- 총 휴식 가능한 시간을 30분으로 잡으려했는데, 구현자체가 너무 어려워서 못했습니다. 추후에 추가하거나 방식을 바꿔야 할 것 같습니다.
