### PR TITLE
feat: #49 - 타이머 종료 시 커스텀 알럿 및 중앙 정렬, 선택 구간 볼드 헬퍼 추가

### DIFF
--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -115,8 +115,10 @@ final class TimerRunViewController: UIViewController {
     buttonBarView.stopButtonTap
       .asDriver()
       .drive(with: self) { vc, _ in
-        vc.viewModel.stop()
-        vc.navigationController?.popViewController(animated: true) // pop되면서 interval도 중지
+        PodoAlertController.presentStopTimerAlert(from: vc, onConfirm: {
+          vc.viewModel.stop()
+          vc.navigationController?.popViewController(animated: true)
+        })
       }
       .disposed(by: disposeBag)
 

--- a/PodoIt/Support/UI/PodoAlertController.swift
+++ b/PodoIt/Support/UI/PodoAlertController.swift
@@ -100,7 +100,7 @@ final class PodoAlertController: UIViewController {
   required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
   // MARK: - Views
-  
+
   private let dimView = UIControl().then {
     $0.backgroundColor = UIColor.black.withAlphaComponent(0.5)
     $0.alpha = 0
@@ -251,11 +251,11 @@ extension PodoAlertController {
     m.addAttribute(
       .paragraphStyle,
       value: p,
-      range: NSRange(location: 0, length: m.length
-    ))
+      range: NSRange(location: 0, length: m.length)
+    )
     return m
   }
-  
+
   private func messageLabelTargetBolding(fullText: String, boldTarget: String) -> NSAttributedString {
     // 기본 스타일은 기본 messageLabel의 Typography값으로 전체는 원 상태 유지
     let base = Typography.attributed(
@@ -265,7 +265,7 @@ extension PodoAlertController {
     )
     // 스타일을 변경해주어야 하니 "가변"상태로 변경
     let m = NSMutableAttributedString(attributedString: base)
-    
+
     // 원하는 일부 부분(target)만 볼드처리
     if let range = fullText.range(of: boldTarget) { // boldTarget 구간만 가져옴
       let ns = NSRange(range, in: fullText) // nsRange로 변환

--- a/PodoIt/Support/UI/PodoAlertController.swift
+++ b/PodoIt/Support/UI/PodoAlertController.swift
@@ -36,11 +36,33 @@ final class PodoAlertController: UIViewController {
       message: message,
       cancelTitle: cancelTitle,
       confirmTitle: confirmTitle,
+      confirmColor: .error,
       onConfirm: onConfirm
     )
     vc.modalPresentationStyle = .overFullScreen // 반투명
     vc.modalTransitionStyle = .crossDissolve // fase in/out
     presenter.present(vc, animated: false) // 알럿 표시
+  }
+  
+  static func presentStopTimerAlert(
+    from presenter: UIViewController,
+    title: String = "아직 목표 시간을 채우지 않았어요.\n그래도 종료할까요?",
+    message: String = "1분 이상 집중한 시간은 그대로 기록돼요.",
+    cancelTitle: String = "계속하기",
+    confirmTitle: String = "그만두기",
+    onConfirm: @escaping () -> Void
+  ) {
+    let vc = PodoAlertController(
+      title: title,
+      message: message,
+      cancelTitle: cancelTitle,
+      confirmTitle: confirmTitle,
+      confirmColor: .primary600,
+      onConfirm: onConfirm
+    )
+    vc.modalPresentationStyle = .overFullScreen
+    vc.modalTransitionStyle = .crossDissolve
+    presenter.present(vc, animated: true)
   }
 
   // MARK: - Init
@@ -51,6 +73,7 @@ final class PodoAlertController: UIViewController {
        message: String,
        cancelTitle: String,
        confirmTitle: String,
+       confirmColor: UIColor,
        onConfirm: @escaping () -> Void)
   {
     self.confirmHandler = onConfirm
@@ -67,6 +90,7 @@ final class PodoAlertController: UIViewController {
       Typography.attributed(confirmTitle, style: .labelLg(weight: .semibold), color: .appWhite),
       for: .normal
     )
+    confirmButton.backgroundColor = confirmColor
   }
 
   @available(*, unavailable)
@@ -99,7 +123,6 @@ final class PodoAlertController: UIViewController {
   }
 
   private let confirmButton = UIButton(type: .system).then {
-    $0.backgroundColor = .error
     $0.layer.cornerRadius = Metrics.buttonCornerRadius
     // $0.contentEdgeInsets = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
     $0.accessibilityIdentifier = "podoAlert.confirm"

--- a/PodoIt/Support/UI/PodoAlertController.swift
+++ b/PodoIt/Support/UI/PodoAlertController.swift
@@ -83,7 +83,7 @@ final class PodoAlertController: UIViewController {
     super.init(nibName: nil, bundle: nil)
 
     titleLabel.attributedText = centered(Typography.attributed(title, style: .headingLg, color: .appBlack))
-    messageLabel.attributedText = centered(Typography.attributed(message, style: .bodyLg(weight: .regular), color: .gray500))
+    messageLabel.attributedText = centered(messageLabelTargetBolding(fullText: message, boldTarget: "1분 이상"))
 
     cancelButton.setAttributedTitle(
       Typography.attributed(cancelTitle, style: .labelLg(weight: .semibold), color: .gray900),
@@ -253,6 +253,26 @@ extension PodoAlertController {
       value: p,
       range: NSRange(location: 0, length: m.length
     ))
+    return m
+  }
+  
+  private func messageLabelTargetBolding(fullText: String, boldTarget: String) -> NSAttributedString {
+    // 기본 스타일은 기본 messageLabel의 Typography값으로 전체는 원 상태 유지
+    let base = Typography.attributed(
+      fullText,
+      style: .bodyLg(weight: .regular),
+      color: .gray500
+    )
+    // 스타일을 변경해주어야 하니 "가변"상태로 변경
+    let m = NSMutableAttributedString(attributedString: base)
+    
+    // 원하는 일부 부분(target)만 볼드처리
+    if let range = fullText.range(of: boldTarget) { // boldTarget 구간만 가져옴
+      let ns = NSRange(range, in: fullText) // nsRange로 변환
+      // 원하는 구간만 ".bold"로 덮어쓰기 (다른 부분은 수정되지 않고 base상태)
+      let boldFont = Typography.font(for: .bodyLg(weight: .bold))
+      m.addAttribute(.font, value: boldFont, range: ns) // 가변으로 만들어준 m에다가 내가 원하는 구간(ns)에 bold(boldFont)처리를 해서 주입
+    }
     return m
   }
 }

--- a/PodoIt/Support/UI/PodoAlertController.swift
+++ b/PodoIt/Support/UI/PodoAlertController.swift
@@ -82,8 +82,8 @@ final class PodoAlertController: UIViewController {
     self.confirmHandler = onConfirm
     super.init(nibName: nil, bundle: nil)
 
-    titleLabel.attributedText = Typography.attributed(title, style: .headingLg, color: .appBlack)
-    messageLabel.attributedText = Typography.attributed(message, style: .bodyLg(weight: .regular), color: .gray500)
+    titleLabel.attributedText = centered(Typography.attributed(title, style: .headingLg, color: .appBlack))
+    messageLabel.attributedText = centered(Typography.attributed(message, style: .bodyLg(weight: .regular), color: .gray500))
 
     cancelButton.setAttributedTitle(
       Typography.attributed(cancelTitle, style: .labelLg(weight: .semibold), color: .gray900),
@@ -100,7 +100,7 @@ final class PodoAlertController: UIViewController {
   required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
   // MARK: - Views
-
+  
   private let dimView = UIControl().then {
     $0.backgroundColor = UIColor.black.withAlphaComponent(0.5)
     $0.alpha = 0
@@ -119,7 +119,6 @@ final class PodoAlertController: UIViewController {
 
   private let messageLabel = UILabel().then {
     $0.numberOfLines = 0
-    $0.textAlignment = .center
   }
 
   private let cancelButton = UIButton(type: .system).then {
@@ -240,5 +239,20 @@ final class PodoAlertController: UIViewController {
     animateOut { [weak self] in
       self?.dismiss(animated: false) { handler() }
     }
+  }
+}
+
+extension PodoAlertController {
+  private func centered(_ attr: NSAttributedString) -> NSAttributedString {
+    let m = NSMutableAttributedString(attributedString: attr)
+    let p = NSMutableParagraphStyle()
+    p.alignment = .center
+    p.lineBreakMode = .byWordWrapping
+    m.addAttribute(
+      .paragraphStyle,
+      value: p,
+      range: NSRange(location: 0, length: m.length
+    ))
+    return m
   }
 }

--- a/PodoIt/Support/UI/PodoAlertController.swift
+++ b/PodoIt/Support/UI/PodoAlertController.swift
@@ -43,10 +43,13 @@ final class PodoAlertController: UIViewController {
     vc.modalTransitionStyle = .crossDissolve // fase in/out
     presenter.present(vc, animated: false) // 알럿 표시
   }
-  
+
   static func presentStopTimerAlert(
     from presenter: UIViewController,
-    title: String = "아직 목표 시간을 채우지 않았어요.\n그래도 종료할까요?",
+    title: String = """
+    아직 목표 시간을 채우지 않았어요.
+    그래도 종료할까요?
+    """,
     message: String = "1분 이상 집중한 시간은 그대로 기록돼요.",
     cancelTitle: String = "계속하기",
     confirmTitle: String = "그만두기",
@@ -110,7 +113,10 @@ final class PodoAlertController: UIViewController {
     $0.clipsToBounds = true
   }
 
-  private let titleLabel = UILabel()
+  private let titleLabel = UILabel().then {
+    $0.numberOfLines = 0
+  }
+
   private let messageLabel = UILabel().then {
     $0.numberOfLines = 0
     $0.textAlignment = .center


### PR DESCRIPTION
## 🔗 관련 이슈

- #49 

## 🔧 PR 요약
- 커스텀 알럿 색상을 고를 수 있도록, `confirmColor` 파라미터 추가
- 타이틀 레이블 여러줄 출력 및 중앙 정렬 처리
- 타이머에서 `stop`시 커스텀 알럿 동작("계속하기" 동작x / "그만두기" -> `stop` + `pop` + `deinit` 확인)
- 중앙 정렬 헬퍼(`centered`) 추가
- 메시지 레이블 특정 구간 볼드 처리 헬퍼(`messageLabelTargetBolding`) 추가

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

| 변함 없는 타이머 삭제 | 제목 2줄 본문 1줄<br>(일부 bold, 중앙정렬 적용) | 제목 2줄 본문 2줄<br>(일부 bold, 중앙정렬 적용) |
|:---:|:---:|:---:|
| <img width="300" height="652" alt="Image" src="https://github.com/user-attachments/assets/eaa04aa5-41ce-4541-be74-73bb14f62d50" /> | <img width="300" height="652" alt="Image" src="https://github.com/user-attachments/assets/e896b55d-0b6a-4b81-89f3-30df12e022cf" /> | <img width="300" height="652" alt="Image" src="https://github.com/user-attachments/assets/3923515c-cc17-4baa-914c-eb693bce73d4" /> |

## 📎 기타 참고사항
- **#123 PR이 merge된 이후에 `develop`으로 변경해서 merge할 예정입니다.**
- 중앙 정렬 헬퍼와 특정 부분 `bold`처리하는 헬퍼는 다른 코드와 컨벤션을 맞추기 위해 주석을 삭제했습니다. 자세히 어떤 코드인지, 어떻게 사용하는지 궁금하시면 완전히 정리되지는 않았지만 아래에 적어둔 Notion 주소를 참고해주시면 감사하겠습니다. 
- [Label 중앙 정렬하는 "centered" 헬퍼 설명](https://iris-ceres-022.notion.site/Podoit-Custom-Alert-Label-2668f738d002802d8394f318e95d4226?source=copy_link)
- [특정 부분 색상 변경하는 `messageLabelTargetBolding` 헬퍼 설명](https://iris-ceres-022.notion.site/Podoit-2668f738d002802ea247e13c9fef1d30?source=copy_link)

