### PR TITLE
chore: #133 - 하드코딩 -> 날짜 자동으로 갱신

### DIFF
--- a/PodoIt/Scenes/Timer/ViewComponent/TimerHeaderView.swift
+++ b/PodoIt/Scenes/Timer/ViewComponent/TimerHeaderView.swift
@@ -14,9 +14,16 @@ final class TimerHeaderView: UIView {
     static let horizontalPadding: CGFloat = 20
   }
 
-  private let dateLabel = UILabel.makeAttributed(
-    text: "8월 19일", style: .headingLg, color: .appBlack, alignment: .left
-  )
+  private let dateLabel: UILabel = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "ko_KR") // 한국어 로케일
+    formatter.dateFormat = "M월 d일"
+    let today = formatter.string(from: Date())
+
+    return UILabel.makeAttributed(
+      text: today, style: .headingLg, color: .appBlack, alignment: .left
+    )
+  }()
 
   private let dividerView = UIView().then {
     $0.backgroundColor = .gray100

--- a/PodoIt/Scenes/Timer/ViewComponent/TimerHeaderView.swift
+++ b/PodoIt/Scenes/Timer/ViewComponent/TimerHeaderView.swift
@@ -14,16 +14,17 @@ final class TimerHeaderView: UIView {
     static let horizontalPadding: CGFloat = 20
   }
 
-  private let dateLabel: UILabel = {
+  private static let dateFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "ko_KR") // 한국어 로케일
     formatter.dateFormat = "M월 d일"
-    let today = formatter.string(from: Date())
 
-    return UILabel.makeAttributed(
-      text: today, style: .headingLg, color: .appBlack, alignment: .left
-    )
+    return formatter
   }()
+
+  private let dateLabel = UILabel.makeAttributed(
+    text: "", style: .headingLg, color: .appBlack, alignment: .left
+  )
 
   private let dividerView = UIView().then {
     $0.backgroundColor = .gray100
@@ -41,6 +42,8 @@ final class TimerHeaderView: UIView {
     super.init(frame: frame)
     setupView()
     setupConstraints()
+    updateDate()
+    setupObservers()
   }
 
   @available(*, unavailable)
@@ -76,5 +79,54 @@ final class TimerHeaderView: UIView {
       $0.leading.equalToSuperview().offset(Layout.horizontalPadding)
       $0.bottom.equalToSuperview() // 전체 높이 계산
     }
+  }
+
+  // MARK: - Date Handling
+
+  private func updateDate() {
+    let today = TimerHeaderView.dateFormatter.string(from: Date())
+    dateLabel.attributedText = Typography.attributed(
+      today,
+      style: .headingLg,
+      color: .appBlack
+    )
+  }
+
+  private func setupObservers() {
+    // 자정 지나서 날짜 바뀔 때
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleDayChanged),
+      name: .NSCalendarDayChanged,
+      object: nil
+    )
+
+    // 시스템 시간대/시간 큰 변경
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleSignificantTimeChange),
+      name: UIApplication.significantTimeChangeNotification,
+      object: nil
+    )
+
+    // 앱 포그라운드 복귀 시(백그라운드 동안 날짜가 바뀌었을 수 있음)
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleWillEnterForeground),
+      name: UIApplication.willEnterForegroundNotification,
+      object: nil
+    )
+  }
+
+  @objc private func handleDayChanged() {
+    updateDate()
+  }
+
+  @objc private func handleSignificantTimeChange() {
+    updateDate()
+  }
+
+  @objc private func handleWillEnterForeground() {
+    updateDate()
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #133 

## 🔧 PR 요약

- 8월 19일로 하드코딩 되어 있던 걸 실시간 날짜로 갱신되도록 수정하였습니다

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

![Simulator Screen Recording - iPhone 16 Pro - 2025-09-09 at 01 31 14](https://github.com/user-attachments/assets/429e239c-e245-4d6b-8b46-2553b80da4a7)

## 📎 기타 참고사항

> 또또또 이슈 번호 안 넣은 죄인... 입니다... 잠와도.. 더블체킹을 생활화 하겠습니다ㅜㅜ