### PR TITLE
feat: #42 - 타이머 UserDefaults로 상태 복원

### DIFF
--- a/PodoIt/App/SceneDelegate.swift
+++ b/PodoIt/App/SceneDelegate.swift
@@ -20,7 +20,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     // Repository 인스턴스를 생성해서 전달
     let repository = SwiftDataManager.shared
-    let rootVC = MainTabBarController(repository: repository)
+    let savedID = TimerRunViewModel.fetchSavedTimerID() // UD에 저장된 UUID값 fetch
+    let rootVC = MainTabBarController(repository: repository, initialTimerID: savedID)
     window.rootViewController = rootVC
     window.makeKeyAndVisible()
 

--- a/PodoIt/AppSettings/AudioSettings.swift
+++ b/PodoIt/AppSettings/AudioSettings.swift
@@ -5,12 +5,30 @@
 //  Created by 서광용 on 9/9/25.
 //
 
+import Foundation
 import RxCocoa
+import RxSwift
 
 final class AudioSettings {
   static let shared = AudioSettings() // 싱글톤
-  private init() {}
+  
+  private let udKey = "isMute_key"
+  private let disposeBag = DisposeBag()
   
   // 사운드 음소거. 값이 바뀔 때마다 이벤트 방출
   let isMute = BehaviorRelay<Bool>(value: false)
+  
+  private init() {
+    // 초기 세팅 (데이터 불러와서 세팅)
+    let data = UserDefaults.standard.object(forKey: self.udKey) as? Bool ?? false
+    isMute.accept(data)
+    
+    isMute
+      .distinctUntilChanged() // 동일 값은 무시
+      .skip(1) // 초기 로드 accept 후에 중복 저장 못하도록 1번은 ud에 저장 무시
+      .subscribe(onNext: { [udKey] value in // udKey만 복사해서 넣음
+        UserDefaults.standard.set(value, forKey: udKey)
+      })
+      .disposed(by: disposeBag)
+  }
 }

--- a/PodoIt/Resources/Info.plist
+++ b/PodoIt/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>ITSAppUsesNonExemptEncryption</key>
+  <false/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>

--- a/PodoIt/Resources/PrivacyInfo.xcprivacy
+++ b/PodoIt/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/PodoIt/Scenes/RootScene/MainTabBarController.swift
+++ b/PodoIt/Scenes/RootScene/MainTabBarController.swift
@@ -38,6 +38,7 @@ final class MainTabBarController: UITabBarController {
     selectedIndex = 0 // psuh전 탭을 TimerVC로 강제. 이래야 TimerRunVC에서 pop해도 TimerVC로 pop 실행됨
     if let nav = viewControllers?.first as? UINavigationController {
       let timerRunVC = TimerRunViewController(timerID: id, repo: repository)
+      timerRunVC.hidesBottomBarWhenPushed = true
       nav.pushViewController(timerRunVC, animated: false)
       self.initialTimerID = nil // 매번 저 화면으로 push할게 아니기에 1번만 하고 nil
     }

--- a/PodoIt/Scenes/RootScene/MainTabBarController.swift
+++ b/PodoIt/Scenes/RootScene/MainTabBarController.swift
@@ -11,10 +11,12 @@ import UIKit
 final class MainTabBarController: UITabBarController {
   // Repository 보관
   private let repository: TimerRepository
+  private var initialTimerID: UUID?
 
   // 지정 이니셜라이저 추가
-  init(repository: TimerRepository) {
+  init(repository: TimerRepository, initialTimerID: UUID? = nil) {
     self.repository = repository
+    self.initialTimerID = initialTimerID
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -27,6 +29,18 @@ final class MainTabBarController: UITabBarController {
     super.viewDidLoad()
     setupAppearance() // 탭바 (컬러/폰트) 설정
     setupViewControllers() // 탭별 화면 연결
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    guard let id = initialTimerID else { return }
+    // 타이머 탭 선택
+    selectedIndex = 0 // psuh전 탭을 TimerVC로 강제. 이래야 TimerRunVC에서 pop해도 TimerVC로 pop 실행됨
+    if let nav = viewControllers?.first as? UINavigationController {
+      let timerRunVC = TimerRunViewController(timerID: id, repo: repository)
+      nav.pushViewController(timerRunVC, animated: false)
+      self.initialTimerID = nil // 매번 저 화면으로 push할게 아니기에 1번만 하고 nil
+    }
   }
 
   private func setupAppearance() {

--- a/PodoIt/Scenes/TimerRun/Model/TimerSessionState.swift
+++ b/PodoIt/Scenes/TimerRun/Model/TimerSessionState.swift
@@ -7,9 +7,9 @@
 import Foundation
 
 struct TimerSessionState {
-  var studySessionStart: Date // 공부 시작한 시간 기록
+//  var studySessionStart: Date // 공부 시작한 시간 기록
   var intervalStart: Date // 현재 구간(공부/휴식)이 시작된 시간 기록
   var isStudying: Bool // 공부 중(true)/휴식 중(false)
   var totalStudySeconds: Int // 지금까지 누적된 총 공부 시간(초)
-  var totalRestSeconds: Int // 지금까지 누적된 총 휴식 시간(초)
+//  var totalRestSeconds: Int // 지금까지 누적된 총 휴식 시간(초)
 }

--- a/PodoIt/Scenes/TimerRun/Model/TimerSessionState.swift
+++ b/PodoIt/Scenes/TimerRun/Model/TimerSessionState.swift
@@ -7,9 +7,7 @@
 import Foundation
 
 struct TimerSessionState {
-//  var studySessionStart: Date // 공부 시작한 시간 기록
   var intervalStart: Date // 현재 구간(공부/휴식)이 시작된 시간 기록
   var isStudying: Bool // 공부 중(true)/휴식 중(false)
   var totalStudySeconds: Int // 지금까지 누적된 총 공부 시간(초)
-//  var totalRestSeconds: Int // 지금까지 누적된 총 휴식 시간(초)
 }

--- a/PodoIt/Scenes/TimerRun/Model/TimerSessionUDSnapshot.swift
+++ b/PodoIt/Scenes/TimerRun/Model/TimerSessionUDSnapshot.swift
@@ -12,6 +12,10 @@ struct TimerSessionUDSnapshot: Codable {
   let isStudying: Bool // 공부 중(true)/휴식 중(false)
   let intervalStart: Date // 현재 구간(공부/휴식)이 시작된 시간 기록
   let totalStudySeconds: Int // 지금까지 누적된 총 공부 시간(초)
-  let restRemainingSeconds: Int // 남은 휴식시간이 끝나기까지 남은 시간
-  let savedAt: Date // 저장된 시간
+  
+  // 휴식 상태 복구를 위한
+  let restAddSeconds: Int
+  let zeroMark: Bool
+  let addedMark: Int?
+  let addSnapshot: Int
 }

--- a/PodoIt/Scenes/TimerRun/Model/TimerSessionUDSnapshot.swift
+++ b/PodoIt/Scenes/TimerRun/Model/TimerSessionUDSnapshot.swift
@@ -1,0 +1,17 @@
+//
+//  TimerSessionUDSnapshot.swift
+//  PodoIt
+//
+//  Created by 서광용 on 9/10/25.
+//
+
+import Foundation
+
+struct TimerSessionUDSnapshot: Codable {
+  let timerID: UUID // uuid
+  let isStudying: Bool // 공부 중(true)/휴식 중(false)
+  let intervalStart: Date // 현재 구간(공부/휴식)이 시작된 시간 기록
+  let totalStudySeconds: Int // 지금까지 누적된 총 공부 시간(초)
+  let restRemainingSeconds: Int // 남은 휴식시간이 끝나기까지 남은 시간
+  let savedAt: Date // 저장된 시간
+}

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -149,6 +149,12 @@ final class TimerRunViewController: UIViewController {
       }
       .disposed(by: disposeBag)
 
+    viewModel.isMuteDriver // 음소거(mute)의 Bool 상태 (아래는 tick 모음이라 계속 호출되서 분리)
+      .drive(with: self) { vc, isMute in
+        vc.headerSectionView.updateMuteIcon(isMute: isMute)
+      }
+      .disposed(by: disposeBag)
+
     // 공부/휴식 상태에 따라서 목표시간 또는 휴식시간 UI를 업데이트
     // combineLatest: 여러개의 Driver 스트림을 합쳐서 하나로 만들어줌
     Driver.combineLatest(
@@ -156,16 +162,14 @@ final class TimerRunViewController: UIViewController {
       viewModel.goalTimeText, // 공부 목표시간 (MM:SS)
       viewModel.studyingTimeText, // 공부중인 시간 (H:MM:SS)
       viewModel.totalRestTimeText, // 총 "휴식 중인 시간" (MM:SS)
-      viewModel.restingTimeText, // "남은 휴식시간" (기본 5분. MM:SS)
-      viewModel.isMuteDriver // 음소거(mute)의 Bool 상태
+      viewModel.restingTimeText // "남은 휴식시간" (기본 5분. MM:SS)
     )
     .drive(with: self) { vc, data in
-      let (isStudying, goalTime, studyingTime, totalRestTime, restingTime, isMute) = data
+      let (isStudying, goalTime, studyingTime, totalRestTime, restingTime) = data
       // 공부/휴식 중 상태에 따른 버튼 UI 업데이트
       vc.buttonSectionView.updateStartPauseButtonImage(isStudying: isStudying)
       vc.progressRestSectionView.updateIsHiddenView(isStudying: isStudying)
       vc.animationSectionView.updateStateImage(isStudying: isStudying)
-      vc.headerSectionView.updateMuteIcon(isMute: isMute)
 
       if isStudying { // 공부중
         vc.timerSectionView.updateGoalTimeUI(goalTime: goalTime, studyingTime: studyingTime)

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -49,6 +49,7 @@ final class TimerRunViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
+    self.hidesBottomBarWhenPushed = true
     configureUI()
     configureLayout()
     loadData()

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -59,6 +59,7 @@ final class TimerRunViewController: UIViewController {
 
   private func loadData() {
     do {
+      viewModel.loadUDSaved() // UD 데이터 불러오기 (없으면 내부 return)
       try viewModel.load()
       if let timer = viewModel.timer {
         configureAll(timer: timer)

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -107,6 +107,8 @@ final class TimerRunViewModel {
     if state.isStudying {
       scheduleGoalEndNotification() // 공부 목표 시간 알림 예약
     }
+    // 앱 진입 후 바로 스냅샷 저장
+    saveSessionUDSnapshot()
   }
   
   // MARK: - UserDefaults 저장/불러오기/삭제
@@ -198,6 +200,8 @@ final class TimerRunViewModel {
     if state.isStudying == false { // 휴식 중
       scheduleRestEndNotification() // 휴식시간이 늘어나니 다시 시간 재계산 후 예약
     }
+    // 휴식 시간이 늘어날 때마다 스냅샷 저장
+    saveSessionUDSnapshot()
   }
 
   /// 시작/일시정지 버튼 토글
@@ -222,6 +226,8 @@ final class TimerRunViewModel {
       cancelGoalEndNotification()
       scheduleRestEndNotification()
     }
+    // 상태 전환 후 스냅샷 저장
+    saveSessionUDSnapshot()
   }
   
   /// 정지
@@ -256,6 +262,8 @@ final class TimerRunViewModel {
       타이머 이름: \(timer.title)
       총 공부 시간: \(TimerRunViewModel.formatHMMSS(seconds: state.totalStudySeconds))
       """)
+      // 세션이 정상적으로 종료되었을 경우: UD 스냅샷을 삭제(초기화)해서 다음 세션에 문제 없도록
+      deleteSessionUDSnapshot()
     } catch {
       print("데이터 저장 실패: \(RepositoryError.saveFailed)")
     }

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -166,6 +166,18 @@ final class TimerRunViewModel {
     UserDefaults.standard.removeObject(forKey: udSnapshotKey)
   }
   
+  // MARK: 앱 라이프 사이클에 따른 UD Snapshot
+  
+  /// 앱이 백그라운드로 갈 때 호출해서 데이터 저장
+  func saveUDOnBackground() {
+    saveSessionUDSnapshot()
+  }
+  
+  /// 외부에서 fetch하기 위한 메서드
+  func loadUDSaved() {
+    fetchSessionUDSnapshot()
+  }
+  
   // MARK: - Actions
   
   /// 타이머 음소거

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -135,7 +135,11 @@ final class TimerRunViewModel {
   
   /// UserDefaults에 데이터 불러오기
   
+  
   /// UserDefaults 데이터 삭제
+  private func deleteSessionUDSnapshot() {
+    UserDefaults.standard.removeObject(forKey: udSnapshotKey)
+  }
   
   // MARK: - Actions
   

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -28,7 +28,7 @@ final class TimerRunViewModel {
 
   private let timerID: UUID
   private let repo: TimerRepository
-  private let udSnapshotKey = "timer_key"
+  private static let udSnapshotKey = "timer_key"
   
   // MARK: - State
 
@@ -127,13 +127,13 @@ final class TimerRunViewModel {
     )
     
     if let data = try? JSONEncoder().encode(snapshot) {
-      UserDefaults.standard.set(data, forKey: udSnapshotKey)
+      UserDefaults.standard.set(data, forKey: Self.udSnapshotKey) // Self는 현재 타입을 의미해서 TimerRunViewModel.ud..와 동일
     }
   }
   
   /// UserDefaults에 데이터 불러오기
   private func fetchSessionUDSnapshot() {
-    guard let savedData = UserDefaults.standard.object(forKey: udSnapshotKey) as? Data else { return } // UD 가져옴
+    guard let savedData = UserDefaults.standard.object(forKey: Self.udSnapshotKey) as? Data else { return } // UD 가져옴
     guard let snapshotData = try? JSONDecoder().decode(TimerSessionUDSnapshot.self, from: savedData) else { return } // UD 디코딩
     
     // 주입받은 timerID가 스냅샷의 ID와 다르게 되면 무시하도록. (안전을 위해)
@@ -163,7 +163,7 @@ final class TimerRunViewModel {
   
   /// UserDefaults 데이터 삭제
   private func deleteSessionUDSnapshot() {
-    UserDefaults.standard.removeObject(forKey: udSnapshotKey)
+    UserDefaults.standard.removeObject(forKey: Self.udSnapshotKey)
   }
   
   // MARK: 앱 라이프 사이클에 따른 UD Snapshot
@@ -486,4 +486,11 @@ extension TimerRunViewModel {
   
   /// 휴식 Notification 예약 취소
   private func cancelRestEndNotification() { NotificationScheduler.cancel(id: NotificationID.restingTimeEnd) }
+  
+  /// SceneDelegate에서 의존성때문에 인스턴스 생성을 못하니, 타입 메서드로 선언해서 가져다사용
+  static func fetchSavedTimerID() -> UUID? {
+    guard let data = UserDefaults.standard.object(forKey: self.udSnapshotKey) as? Data,
+          let snapshot = try? JSONDecoder().decode(TimerSessionUDSnapshot.self, from: data) else { return nil }
+    return snapshot.timerID
+  }
 }

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -34,12 +34,13 @@ final class TimerRunViewModel {
   private(set) var timer: TimerModel?
   private let disposeBag = DisposeBag()
   
+  // FIXME: 사용하지 않을 것 같은 값들 주석. 끝내고도 사용 안하면 삭제 예정
   private(set) var state = TimerSessionState(
-    studySessionStart: Date(), // UD에서도 사용 안하면 삭제
+//    studySessionStart: Date(), // UD에서도 사용 안하면 삭제
     intervalStart: Date(),
     isStudying: true,
     totalStudySeconds: 0,
-    totalRestSeconds: 0 // UD에서도 사용 안하면 삭제
+//    totalRestSeconds: 0 // UD에서도 사용 안하면 삭제
   )
   
   // isRunningRelay가 값이 바뀔 때마다 이벤트 방출
@@ -338,9 +339,6 @@ extension TimerRunViewModel {
     if state.isStudying {
       state.totalStudySeconds += intervalTime // 공부 시간 누적
       print("현재까지 총 공부 시간: \(state.totalStudySeconds)")
-    } else {
-      state.totalRestSeconds += intervalTime // 휴식 시간 누적
-      print("현재까지 총 휴식 시간: \(state.totalRestSeconds)")
     }
   }
   

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -37,11 +37,9 @@ final class TimerRunViewModel {
   
   // FIXME: 사용하지 않을 것 같은 값들 주석. 끝내고도 사용 안하면 삭제 예정
   private(set) var state = TimerSessionState(
-//    studySessionStart: Date(), // UD에서도 사용 안하면 삭제
     intervalStart: Date(),
     isStudying: true,
     totalStudySeconds: 0,
-//    totalRestSeconds: 0 // UD에서도 사용 안하면 삭제
   )
   
   // isRunningRelay가 값이 바뀔 때마다 이벤트 방출
@@ -115,26 +113,51 @@ final class TimerRunViewModel {
   
   /// UserDefaults에 데이터 저장
   private func saveSessionUDSnapshot() {
-    let now = Date()
-    // 남은 휴식시간 remainingRestSeconds으로 계산하여 반환
-    let remainTime = state.isStudying ? 0 : remainingRestSeconds()
-    
-    let snapShot = TimerSessionUDSnapshot(
+    let snapshot = TimerSessionUDSnapshot(
       timerID: self.timerID,
       isStudying: state.isStudying,
       intervalStart: state.intervalStart,
       totalStudySeconds: state.totalStudySeconds,
-      restRemainingSeconds: remainTime,
-      savedAt: now
+      restAddSeconds: self.restAddSeconds,
+      zeroMark: self.zeroMark,
+      addedMark: self.addedMark,
+      addSnapshot: self.addSnapshot
     )
     
-    if let data = try? JSONEncoder().encode(snapShot) {
+    if let data = try? JSONEncoder().encode(snapshot) {
       UserDefaults.standard.set(data, forKey: udSnapshotKey)
     }
   }
   
   /// UserDefaults에 데이터 불러오기
-  
+  private func fetchSessionUDSnapshot() {
+    guard let savedData = UserDefaults.standard.object(forKey: udSnapshotKey) as? Data else { return } // UD 가져옴
+    guard let snapshotData = try? JSONDecoder().decode(TimerSessionUDSnapshot.self, from: savedData) else { return } // UD 디코딩
+    
+    // 주입받은 timerID가 스냅샷의 ID와 다르게 되면 무시하도록. (안전을 위해)
+    guard snapshotData.timerID == self.timerID else { return }
+    
+    // 상태 복원
+    self.state.isStudying = snapshotData.isStudying
+    self.state.intervalStart = snapshotData.intervalStart
+    self.state.totalStudySeconds = snapshotData.totalStudySeconds
+    
+    self.restAddSeconds = snapshotData.restAddSeconds
+    self.zeroMark = snapshotData.zeroMark
+    self.addedMark = snapshotData.addedMark
+    self.addSnapshot = snapshotData.addSnapshot
+    
+    self.isStudyingRelay.accept(snapshotData.isStudying) // 공부중인지 UI가 알아야 바뀌니까 accept
+    // TODO: 이거 startAndPause의 알림 재예약과 로직이 동일하니, 하나의 메서드로 분리하자
+    // 상태 전환때마다 알림 재예약
+    if state.isStudying { // 휴식 -> 공부로 변경: 휴식 취소하고, 공부 알림 예약
+      cancelRestEndNotification()
+      scheduleGoalEndNotification()
+    } else { // 공부 -> 휴식으로 변경: 공부 취소하고, 휴식 알리 ㅁ예약
+      cancelGoalEndNotification()
+      scheduleRestEndNotification()
+    }
+  }
   
   /// UserDefaults 데이터 삭제
   private func deleteSessionUDSnapshot() {

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -35,11 +35,11 @@ final class TimerRunViewModel {
   private let disposeBag = DisposeBag()
   
   private(set) var state = TimerSessionState(
-    studySessionStart: Date(),
+    studySessionStart: Date(), // UD에서도 사용 안하면 삭제
     intervalStart: Date(),
     isStudying: true,
     totalStudySeconds: 0,
-    totalRestSeconds: 0 // UserDefaults 써서 앱 껐다 켜졌을때 시간 계산에 사용됨. 그 전에는 사용 x
+    totalRestSeconds: 0 // UD에서도 사용 안하면 삭제
   )
   
   // isRunningRelay가 값이 바뀔 때마다 이벤트 방출

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -250,6 +250,9 @@ final class TimerRunViewModel {
     cancelGoalEndNotification()
     cancelRestEndNotification()
     
+    // UD 스냅샷을 삭제(초기화)해서 다음 세션에 문제 없도록
+    deleteSessionUDSnapshot()
+    
     // 총 공부시간이 60초 이상일 경우에만 save()
     guard state.totalStudySeconds > 59 else { return }
     save()
@@ -274,8 +277,6 @@ final class TimerRunViewModel {
       타이머 이름: \(timer.title)
       총 공부 시간: \(TimerRunViewModel.formatHMMSS(seconds: state.totalStudySeconds))
       """)
-      // 세션이 정상적으로 종료되었을 경우: UD 스냅샷을 삭제(초기화)해서 다음 세션에 문제 없도록
-      deleteSessionUDSnapshot()
     } catch {
       print("데이터 저장 실패: \(RepositoryError.saveFailed)")
     }

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -28,6 +28,7 @@ final class TimerRunViewModel {
 
   private let timerID: UUID
   private let repo: TimerRepository
+  private let udSnapshotKey = "timer_key"
   
   // MARK: - State
 
@@ -109,6 +110,32 @@ final class TimerRunViewModel {
       scheduleGoalEndNotification() // 공부 목표 시간 알림 예약
     }
   }
+  
+  // MARK: - UserDefaults 저장/불러오기/삭제
+  
+  /// UserDefaults에 데이터 저장
+  private func saveSessionUDSnapshot() {
+    let now = Date()
+    // 남은 휴식시간 remainingRestSeconds으로 계산하여 반환
+    let remainTime = state.isStudying ? 0 : remainingRestSeconds()
+    
+    let snapShot = TimerSessionUDSnapshot(
+      timerID: self.timerID,
+      isStudying: state.isStudying,
+      intervalStart: state.intervalStart,
+      totalStudySeconds: state.totalStudySeconds,
+      restRemainingSeconds: remainTime,
+      savedAt: now
+    )
+    
+    if let data = try? JSONEncoder().encode(snapShot) {
+      UserDefaults.standard.set(data, forKey: udSnapshotKey)
+    }
+  }
+  
+  /// UserDefaults에 데이터 불러오기
+  
+  /// UserDefaults 데이터 삭제
   
   // MARK: - Actions
   


### PR DESCRIPTION
## 🔗 관련 이슈

- #42 
- #46 

## 🔧 PR 요약
- UserDefaults 추가, 불러오기, 삭제 구현
- 음소거, 휴식/공부, 휴식 시간 추가에 UD 추가
- 정지 시 UD 삭제
- 신 델리게이트에서 MainTabBarController의 init에 ID를 받아, ID가 있으면 TimerVC위에 TimerRunVC로 push

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/a5564a89-86d6-4d01-b8cb-5ee87453dbbd" width="300" />

## 📎 기타 참고사항

> 추가적으로 논의하고 싶은 내용이 있다면 작성해주세요.
