### PR TITLE
chore: #141 - 전체적인 UI 수정

### DIFF
--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -273,6 +273,8 @@ final class TimerEditViewController: UIViewController {
 
     applyCollapsedUI(animated: false)
     updateCollapsedLabelText()
+
+    updateSaveButtonStyle()
   }
 
   private func setupEditMode() {
@@ -310,6 +312,7 @@ final class TimerEditViewController: UIViewController {
         setEmojiOnButton(editing.iconName)
       }
     }
+    updateSaveButtonStyle()
   }
 
   private func setupGestures() {
@@ -633,6 +636,32 @@ final class TimerEditViewController: UIViewController {
     setNameFieldError(text.isEmpty)
   }
 
+  // 폼 유효성 검사 : 제목 공백/중복 체크
+  private func isFormValid() -> Bool {
+    let title = (nameTextField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    return !title.isEmpty
+  }
+
+  // 저장 버튼 스타일 동기화
+  private func updateSaveButtonStyle() {
+    let valid = isFormValid()
+    saveButton.isEnabled = valid
+
+    if valid {
+      saveButton.backgroundColor = Palette.Primary.p600
+      saveButton.setAttributedTitle(
+        Typography.attributed("저장하기", style: .labelLg(weight: .semibold), color: .appWhite),
+        for: .normal
+      )
+    } else {
+      saveButton.backgroundColor = Palette.Gray.g200
+      saveButton.setAttributedTitle(
+        Typography.attributed("저장하기", style: .labelLg(weight: .semibold), color: Palette.Gray.g400),
+        for: .normal
+      )
+    }
+  }
+
   // MARK: - Actions
 
   @objc private func dismissKeyboards() {
@@ -658,6 +687,7 @@ final class TimerEditViewController: UIViewController {
       UIImpactFeedbackGenerator(style: .light).impactOccurred()
       setNameFieldError(true, animated: true)
       nameTextField.becomeFirstResponder()
+      updateSaveButtonStyle()
       return
     }
 
@@ -667,6 +697,7 @@ final class TimerEditViewController: UIViewController {
       setNameFieldError(true, animated: true)
       nameTextField.becomeFirstResponder()
       showToast("중복된 이름이 있어요.", icon: UIImage(named: "bang"), above: saveButton)
+      updateSaveButtonStyle()
       return
     }
 
@@ -738,6 +769,8 @@ final class TimerEditViewController: UIViewController {
     UIImpactFeedbackGenerator(style: .soft).impactOccurred()
     sender.text = ""
     sender.resignFirstResponder()
+
+    updateSaveButtonStyle()
   }
 
   private func setEmojiOnButton(_ emoji: String) {
@@ -770,6 +803,7 @@ final class TimerEditViewController: UIViewController {
     emojiButton.tintColor = Palette.Primary.p600
     dashedCircleView.isHidden = false
     UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    updateSaveButtonStyle()
   }
 
   // 이름 편집 중 실시간 검증 (지우면 빨간 스트로크)
@@ -781,6 +815,7 @@ final class TimerEditViewController: UIViewController {
       return
     }
     validateNameField()
+    updateSaveButtonStyle()
   }
 }
 
@@ -841,6 +876,7 @@ extension TimerEditViewController: UIPickerViewDataSource, UIPickerViewDelegate 
     pickerView.reloadComponent(0)
     updateUnitLabelPosition()
     if !isPickerExpanded { updateCollapsedLabelText() }
+    updateSaveButtonStyle()
   }
 
   func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -47,6 +47,8 @@ final class TimerEditViewController: UIViewController {
     static let pickerRowHeight: CGFloat = 48
     static let unitRightInset: CGFloat = 16
     static let unitLeftSpacing: CGFloat = 8
+    // 단위 라벨을 박스 중앙으로부터 고정 오프셋
+    static let unitCenterFixedOffset: CGFloat = 44
   }
 
   // MARK: - UI Components
@@ -135,7 +137,7 @@ final class TimerEditViewController: UIViewController {
 
   private lazy var unitLabel = UILabel().then { [isTest = TimerEditViewController.isTestMode] in
     let unit = isTest ? "초" : "분"
-    $0.attributedText = Typography.attributed(unit, style: .headingXl(weight: .semibold), color: .gray600)
+    $0.attributedText = Typography.attributed(unit, style: .headingXl(weight: .semibold), color: .appBlack)
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     $0.setContentHuggingPriority(.required, for: .horizontal)
   }
@@ -198,6 +200,8 @@ final class TimerEditViewController: UIViewController {
   // private var minutePickerMinHeightConstraint: Constraint?
   private var timePickerMinHeightConstraint: Constraint?
   private var isPickerExpanded = false
+  private var currentSelectedRow: Int = 0
+  private var unitLeadingConstraint: Constraint?
 
   // MARK: - Data
 
@@ -256,6 +260,8 @@ final class TimerEditViewController: UIViewController {
 
     if let idx = timeOptions.firstIndex(of: selectedTime) {
       timePicker.selectRow(idx, inComponent: 0, animated: false)
+      currentSelectedRow = idx
+      updateUnitLabelPosition()
     }
 
 //    if let idx = minuteOptions.firstIndex(of: selectedMinutes) {
@@ -284,11 +290,15 @@ final class TimerEditViewController: UIViewController {
 
       if let editIdx = timeOptions.firstIndex(of: selectedTime) {
         timePicker.selectRow(editIdx, inComponent: 0, animated: false)
+        currentSelectedRow = editIdx
+        updateUnitLabelPosition()
       } else if let nearest = timeOptions.min(by: { abs($0 - selectedTime) < abs($1 - selectedTime) }),
                 let idx = timeOptions.firstIndex(of: nearest)
       {
         selectedTime = nearest
         timePicker.selectRow(idx, inComponent: 0, animated: false)
+        currentSelectedRow = idx
+        updateUnitLabelPosition()
       }
 
 //      selectedMinutes = editing.goalTime
@@ -439,7 +449,7 @@ final class TimerEditViewController: UIViewController {
     timePicker.snp.makeConstraints {
       $0.centerY.equalToSuperview()
       $0.leading.equalToSuperview()
-      $0.trailing.equalTo(unitLabel.snp.leading).offset(-Metrics.unitLeftSpacing)
+      $0.trailing.equalToSuperview()
       $0.top.greaterThanOrEqualToSuperview()
       $0.bottom.lessThanOrEqualToSuperview()
       $0.width.greaterThanOrEqualTo(Metrics.inlinePickerMinWidth)
@@ -536,7 +546,7 @@ final class TimerEditViewController: UIViewController {
 //    number.append(unit)
 //    collapsedValueLabel.attributedText = number
 
-    let unit = Typography.attributed(unitText, style: .headingXl(weight: .semibold), color: .gray600)
+    let unit = Typography.attributed(unitText, style: .headingXl(weight: .semibold), color: .appBlack)
     number.append(unit)
     collapsedValueLabel.attributedText = number
   }
@@ -564,6 +574,8 @@ final class TimerEditViewController: UIViewController {
     timePickerMinHeightConstraint?.activate()
     goalContainerHeightConstraint?.update(offset: Metrics.goalContainerHeightExpanded)
     updateValueAreaStyle(isCollapsed: false)
+
+    updateUnitLabelPosition()
 
     let changes = { self.view.layoutIfNeeded() }
     animated ? UIView.animate(withDuration: 0.28, delay: 0, usingSpringWithDamping: 0.9, initialSpringVelocity: 0.6, options: .curveEaseInOut, animations: changes) : changes()
@@ -781,30 +793,70 @@ extension TimerEditViewController: UIPickerViewDataSource, UIPickerViewDelegate 
                   forComponent component: Int,
                   reusing view: UIView?) -> UIView
   {
-    let label = (view as? UILabel) ?? UILabel()
-    // label.text = "\(minuteOptions[row])"
-    label.text = "\(timeOptions[row])"
-    label.font = Typography.font(for: .displayMd(weight: .semibold))
-    label.textColor = .appBlack
-    label.textAlignment = .center
-    label.adjustsFontForContentSizeCategory = true
+    let container: UIView
+    let numberLabel: UILabel
 
-    label.isAccessibilityElement = true
-    // label.accessibilityLabel = "\(minuteOptions[row])분"
-    let unit = TimerEditViewController.isTestMode ? "초" : "분"
-    label.accessibilityLabel = "\(timeOptions[row])\(unit)"
+    if let reused = view as? UIView, let n = reused.viewWithTag(4001) as? UILabel {
+      container = reused
+      numberLabel = n
+    } else {
+      container = UIView(frame: CGRect(x: 0, y: 0, width: pickerView.bounds.width, height: Metrics.pickerRowHeight))
+      container.autoresizingMask = [.flexibleWidth]
 
-    return label
+      numberLabel = UILabel()
+      numberLabel.tag = 4001
+      numberLabel.textAlignment = .center
+      numberLabel.adjustsFontForContentSizeCategory = true
+      container.addSubview(numberLabel)
+    }
+
+    let valueText = "\(timeOptions[row])"
+    numberLabel.attributedText = Typography.attributed(valueText, style: .displayMd(weight: .semibold), color: .appBlack)
+
+    // 숫자 라벨을 좌측으로 delta만큼
+    let unitText = TimerEditViewController.isTestMode ? "초" : "분"
+    let unitFont = Typography.font(for: .headingXl(weight: .semibold))
+    let unitWidth = (unitText as NSString).size(withAttributes: [.font: unitFont]).width
+    let delta = (unitWidth + Metrics.unitLeftSpacing) / 2.0
+
+    numberLabel.snp.remakeConstraints { make in
+      make.centerY.equalToSuperview()
+      make.centerX.equalToSuperview().offset(-delta)
+    }
+
+    container.isAccessibilityElement = true
+    container.accessibilityLabel = "\(valueText)\(unitText)"
+    return container
   }
 
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
     // selectedMinutes = minuteOptions[row]
     selectedTime = timeOptions[row]
+    currentSelectedRow = row
+    pickerView.reloadComponent(0)
+    updateUnitLabelPosition()
     if !isPickerExpanded { updateCollapsedLabelText() }
   }
 
   func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
     Metrics.pickerRowHeight
+  }
+}
+
+// MARK: - Unit Label Positioning
+
+private extension TimerEditViewController {
+  func updateUnitLabelPosition() {
+    // 박스 중앙에서 고정 오프셋 위치에 단위 배치
+    let offset = Metrics.unitCenterFixedOffset
+
+    unitLabel.snp.remakeConstraints {
+      $0.centerY.equalTo(goalValueArea)
+      $0.leading.equalTo(goalValueArea.snp.centerX).offset(offset)
+    }
+
+    // 레이아웃 반영
+    view.layoutIfNeeded()
   }
 }
 

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -320,7 +320,7 @@ final class TimerEditViewController: UIViewController {
     emojiButton.addGestureRecognizer(longPressGesture)
 
     // 화면 탭으로 이모지 키보드 닫기
-    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissEmojiKeyboard))
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboards))
     tapGesture.cancelsTouchesInView = false
     view.addGestureRecognizer(tapGesture)
   }
@@ -634,6 +634,10 @@ final class TimerEditViewController: UIViewController {
   }
 
   // MARK: - Actions
+
+  @objc private func dismissKeyboards() {
+    view.endEditing(true)
+  }
 
   @objc private func backButtonTapped() {
     navigationController?.popViewController(animated: true)

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -656,24 +656,25 @@ final class TimerEditViewController: UIViewController {
 
     guard !title.isEmpty else {
       UIImpactFeedbackGenerator(style: .light).impactOccurred()
+      setNameFieldError(true, animated: true)
+      nameTextField.becomeFirstResponder()
       return
     }
 
     // 중복 제목
     if viewModel.hasDuplicateTitle(title) {
       UIImpactFeedbackGenerator(style: .light).impactOccurred()
+      setNameFieldError(true, animated: true)
+      nameTextField.becomeFirstResponder()
       showToast("중복된 이름이 있어요.", icon: UIImage(named: "bang"), above: saveButton)
       return
     }
 
     setNameFieldError(false, animated: true)
 
-    let minutes: Int
-    if TimerEditViewController.isTestMode {
-      minutes = max(1, Int(ceil(Double(selectedTime) / 60.0)))
-    } else {
-      minutes = selectedTime
-    }
+    let minutes: Int = TimerEditViewController.isTestMode
+      ? max(1, Int(ceil(Double(selectedTime) / 60.0)))
+      : selectedTime
 
     do {
       try viewModel.save(title: title, iconName: icon, goalMinutes: minutes)

--- a/PodoIt/Scenes/Timer/View/TimerViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerViewController.swift
@@ -276,6 +276,7 @@ final class TimerViewController: UIViewController, UICollectionViewDelegateFlowL
       $0.centerX.equalToSuperview()
       $0.height.equalTo(Layout.addButtonHeight)
     }
+    collectionView.contentInset.bottom = Layout.addButtonHeight + 16
   }
 
   // MARK: - UICollectionViewDelegateFlowLayout

--- a/PodoIt/Scenes/Timer/View/TimerViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerViewController.swift
@@ -255,7 +255,8 @@ final class TimerViewController: UIViewController, UICollectionViewDelegateFlowL
 
     backgroundContainerView.snp.makeConstraints {
       $0.top.equalTo(headerView.snp.bottom).offset(20)
-      $0.leading.trailing.bottom.equalToSuperview()
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(view.safeAreaLayoutGuide)
     }
 
     collectionView.snp.makeConstraints {
@@ -266,7 +267,8 @@ final class TimerViewController: UIViewController, UICollectionViewDelegateFlowL
 
     emptyStateView.snp.makeConstraints {
       $0.centerX.equalToSuperview()
-      $0.top.equalTo(backgroundContainerView.snp.top).offset(Layout.emptyTopOffset)
+      $0.centerY.equalTo(backgroundContainerView.snp.centerY)
+      $0.leading.trailing.equalToSuperview().inset(Layout.sectionInset.left)
     }
 
     addButton.snp.makeConstraints {

--- a/PodoIt/Scenes/Timer/View/TimerViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerViewController.swift
@@ -47,7 +47,7 @@ final class TimerViewController: UIViewController, UICollectionViewDelegateFlowL
     static let sectionSpacing: CGFloat = 16
     static let dividerHeight: CGFloat = 1
     static let emptyTopOffset: CGFloat = 240
-    static let addButtonBottomOffset: CGFloat = -20
+    static let addButtonBottomOffset: CGFloat = -16
     static let addButtonHeight: CGFloat = 48
     static let minimumLineSpacing: CGFloat = 12
     static let sectionInset = UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20)

--- a/PodoIt/Scenes/Timer/ViewComponent/EmptyStateView.swift
+++ b/PodoIt/Scenes/Timer/ViewComponent/EmptyStateView.swift
@@ -23,6 +23,12 @@ final class EmptyStateView: UIView {
     $0.numberOfLines = 0
   }
 
+  private lazy var stackView = UIStackView(arrangedSubviews: [titleLabel, descriptionLabel]).then {
+    $0.axis = .vertical
+    $0.spacing = 14
+    $0.alignment = .center
+  }
+
   override init(frame: CGRect) {
     super.init(frame: frame)
     setupView()
@@ -36,6 +42,7 @@ final class EmptyStateView: UIView {
 
   private func setupView() {
     [titleLabel, descriptionLabel].forEach { addSubview($0) }
+    addSubview(stackView)
   }
 
   private func setupConstraints() {
@@ -46,6 +53,12 @@ final class EmptyStateView: UIView {
     descriptionLabel.snp.makeConstraints {
       $0.top.equalTo(titleLabel.snp.bottom).offset(14)
       $0.leading.trailing.bottom.equalToSuperview()
+    }
+
+    stackView.snp.makeConstraints {
+      $0.centerX.centerY.equalToSuperview()
+      $0.centerY.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(20)
     }
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #141 

## 🔧 PR 요약

- 타이머 비었을 때 Lable 수정
- 초/분 라벨 picker 안에 넣기
- 여백 클릭 시 키보드 내리게
- 마지막 셀에서 최대 갯수 도달 버튼까지 16만큼
- 중복 제목 입력 시 토스트 알럿 + 인풋 스트로크
- 저장하기 활성화/비활성화

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
![Simulator Screen Recording - iPhone 16 Pro - 2025-09-10 at 21 08 17](https://github.com/user-attachments/assets/86937f2e-41e8-435a-829e-eed774896b6c)