### PR TITLE
chore: #150 - 통계 오늘 날짜 선택 되어있을때 버튼 hidden 처리

### DIFF
--- a/PodoIt/Scenes/Stats/View/StatsViewController.swift
+++ b/PodoIt/Scenes/Stats/View/StatsViewController.swift
@@ -17,6 +17,8 @@ final class StatsViewController: UIViewController {
   private enum Metrics {
     static let addButtonBottomOffset: CGFloat = -16
     static let addButtonHeight: CGFloat = 36
+    static let todayHiddenBottomOffset: CGFloat = 0
+    static let todayVisibleBottomOffset: CGFloat = -48
   }
 
   // MARK: - Properties
@@ -29,6 +31,8 @@ final class StatsViewController: UIViewController {
   private let calendarView = CalendarView()
   private let calendarColorView = CalendarColorView()
   private let summaryView = StatsSummaryView()
+
+  private var contentStackBottomConstraint: Constraint?
 
   private let scrollView = UIScrollView().then {
     $0.backgroundColor = .gray100
@@ -74,7 +78,7 @@ final class StatsViewController: UIViewController {
     bind()
     viewModel.viewDidLoad()
   }
-  
+
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     todayButton.layer.shadowPath = UIBezierPath(
@@ -113,7 +117,8 @@ final class StatsViewController: UIViewController {
     contentStackView.snp.makeConstraints {
       $0.top.equalToSuperview()
       $0.directionalHorizontalEdges.equalToSuperview()
-      $0.bottom.equalToSuperview().offset(-48)
+      contentStackBottomConstraint = $0.bottom.equalToSuperview()
+        .offset(Metrics.todayHiddenBottomOffset).constraint
       $0.width.equalTo(scrollView.snp.width)
     }
 
@@ -180,6 +185,19 @@ final class StatsViewController: UIViewController {
       .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
       .subscribe(onNext: { [weak self] in
         self?.calendarView.goToToday()
+        self?.scrollToTop(animated: true)
+      })
+      .disposed(by: disposeBag)
+
+    // 오늘 날짜 선택시 버튼 히든 처리
+    viewModel.isTodaySelected
+      .drive(onNext: { [weak self] isToday in
+        self?.todayButton.isHidden = isToday
+        self?.contentStackBottomConstraint?.update(
+          offset: isToday ? Metrics.todayHiddenBottomOffset
+            : Metrics.todayVisibleBottomOffset
+        )
+        self?.view.layoutIfNeeded()
       })
       .disposed(by: disposeBag)
   }
@@ -195,5 +213,10 @@ final class StatsViewController: UIViewController {
       }
     )
     present(sheet, animated: true)
+  }
+  
+  private func scrollToTop(animated: Bool = false) {
+    let y = -scrollView.adjustedContentInset.top
+    scrollView.setContentOffset(CGPoint(x: 0, y: y), animated: animated)
   }
 }

--- a/PodoIt/Scenes/Stats/ViewComponent/Summary/StatsSummaryView.swift
+++ b/PodoIt/Scenes/Stats/ViewComponent/Summary/StatsSummaryView.swift
@@ -44,7 +44,7 @@ final class StatsSummaryView: UIView {
   private let segmentedControl = StatsCustomSegmentedControl(items: ["일간", "월간"])
 
   private let emptyView = UIView().then {
-    $0.backgroundColor = .appWhite
+    $0.backgroundColor = .clear
     $0.isHidden = true
   }
 

--- a/PodoIt/Scenes/Stats/ViewModel/StatsViewModel.swift
+++ b/PodoIt/Scenes/Stats/ViewModel/StatsViewModel.swift
@@ -25,6 +25,7 @@ final class StatsViewModel {
   private(set) lazy var summary: Driver<SummaryUI> = buildSummary()
   // 달의 일별 집중 분 출력
   private(set) lazy var monthHeatMap: Driver<[Int: Int]> = makeMonthHeatMap()
+  let isTodaySelected: Driver<Bool>
 
   // MARK: - Private
 
@@ -34,6 +35,11 @@ final class StatsViewModel {
 
   init(repo: StatsRepository = SwiftDataManager.shared) {
     self.repo = repo
+    
+    self.isTodaySelected = selectedDate
+      .asDriver()
+      .map { Calendar.current.isDateInToday($0) }
+      .distinctUntilChanged()
 
     NotificationCenter.default.rx.notification(.statsDidChange)
       .observe(on: MainScheduler.instance)


### PR DESCRIPTION
## 🔗 관련 이슈

- #150

## 🔧 PR 요약

- 통계 오늘 날짜 선택 되어있을때 버튼 hidden 처리
- 오늘 날짜 탭시 스크롤뷰 상단으로 이동 추가
- 탭바 Chip 그림자 잘리는거 수정

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷

https://github.com/user-attachments/assets/c59ab168-f0a0-448f-8827-912d881cf4f8