### PR TITLE
refactor: #161 - UUID를 통한 fetch 대신, timer model 직접 주입으로 리팩토링

### DIFF
--- a/PodoIt/Scenes/RootScene/MainTabBarController.swift
+++ b/PodoIt/Scenes/RootScene/MainTabBarController.swift
@@ -37,7 +37,11 @@ final class MainTabBarController: UITabBarController {
     // 타이머 탭 선택
     selectedIndex = 0 // psuh전 탭을 TimerVC로 강제. 이래야 TimerRunVC에서 pop해도 TimerVC로 pop 실행됨
     if let nav = viewControllers?.first as? UINavigationController {
-      let timerRunVC = TimerRunViewController(timerID: id, repo: repository)
+      guard let timer = try? repository.fetch(by: id) else {
+        self.initialTimerID = nil
+        return
+      }
+      let timerRunVC = TimerRunViewController(timer: timer, repo: repository)
       timerRunVC.hidesBottomBarWhenPushed = true
       nav.pushViewController(timerRunVC, animated: false)
       self.initialTimerID = nil // 매번 저 화면으로 push할게 아니기에 1번만 하고 nil

--- a/PodoIt/Scenes/Timer/View/TimerViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerViewController.swift
@@ -424,7 +424,7 @@ extension TimerViewController: UICollectionViewDataSource {
       guard let self = self else { return }
       let timer = self.timers[indexPath.item]
       // 타이머 실행 화면으로 이동
-      let runVC = TimerRunViewController(timerID: timer.timerID, repo: self.repository) // UUID 전달
+      let runVC = TimerRunViewController(timer: timer, repo: self.repository) // timer 전달
       runVC.hidesBottomBarWhenPushed = true // 탭바 숨기기
       self.navigationController?.pushViewController(runVC, animated: true)
     }

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -19,9 +19,8 @@ final class TimerRunViewController: UIViewController {
 
   // MARK: - init
 
-  init(timerID: UUID, repo: TimerRepository) {
-    // UUID를 받아올 때마다 새로운 VM을 생성
-    self.viewModel = TimerRunViewModel(timerID: timerID, repo: repo)
+  init(timer: TimerModel, repo: TimerRepository) {
+    self.viewModel = TimerRunViewModel(timer: timer, repo: repo)
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -52,22 +51,16 @@ final class TimerRunViewController: UIViewController {
     self.hidesBottomBarWhenPushed = true
     configureUI()
     configureLayout()
-    loadData()
+    configureTimer()
     bind()
   }
 
   // MARK: - Data Loading
 
-  private func loadData() {
-    do {
-      viewModel.loadUDSaved() // UD 데이터 불러오기 (없으면 내부 return)
-      try viewModel.load()
-      if let timer = viewModel.timer {
-        configureAll(timer: timer)
-      }
-    } catch {
-      print("타이머 데이터 로딩 실패: \(error)")
-    }
+  private func configureTimer() {
+    viewModel.loadUDSaved() // UD 데이터 불러오기 (없으면 내부 return)
+    viewModel.setupTimer()
+    configureAll(timer: viewModel.timer)
   }
 
   // MARK: - configureUI

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -26,13 +26,13 @@ enum RestAddCase {
 final class TimerRunViewModel {
   // MARK: - Dependencies
 
-  private let timerID: UUID
+//  private let timerID: UUID
   private let repo: TimerRepository
   private static let udSnapshotKey = "timer_key"
   
   // MARK: - State
 
-  private(set) var timer: TimerModel?
+  private(set) var timer: TimerModel
   private let disposeBag = DisposeBag()
   
   // FIXME: 사용하지 않을 것 같은 값들 주석. 끝내고도 사용 안하면 삭제 예정
@@ -90,20 +90,15 @@ final class TimerRunViewModel {
   
   // MARK: - init
 
-  init(timerID: UUID, repo: TimerRepository) {
-    self.timerID = timerID
+  init(timer: TimerModel, repo: TimerRepository) {
+    self.timer = timer
     self.repo = repo
+    goalTime = timer.goalTime * 60 // Int값을 초 단위로 변경
   }
   
   // MARK: - Data Loading
   
-  // 받아온 UUID를 기준으로 SwiftData에서 데이터를 바인딩
-  func load() throws {
-    guard let entity = try repo.fetch(by: timerID) else {
-      throw RepositoryError.entityNotFound
-    }
-    timer = entity
-    goalTime = entity.goalTime * 60 // Int값을 초 단위로 변경
+  func setupTimer() {
     if state.isStudying {
       scheduleGoalEndNotification() // 공부 목표 시간 알림 예약
     }
@@ -116,7 +111,7 @@ final class TimerRunViewModel {
   /// UserDefaults에 데이터 저장
   private func saveSessionUDSnapshot() {
     let snapshot = TimerSessionUDSnapshot(
-      timerID: self.timerID,
+      timerID: timer.timerID,
       isStudying: state.isStudying,
       intervalStart: state.intervalStart,
       totalStudySeconds: state.totalStudySeconds,
@@ -137,7 +132,7 @@ final class TimerRunViewModel {
     guard let snapshotData = try? JSONDecoder().decode(TimerSessionUDSnapshot.self, from: savedData) else { return } // UD 디코딩
     
     // 주입받은 timerID가 스냅샷의 ID와 다르게 되면 무시하도록. (안전을 위해)
-    guard snapshotData.timerID == self.timerID else { return }
+    guard snapshotData.timerID == timer.timerID else { return }
     
     // 상태 복원
     self.state.isStudying = snapshotData.isStudying
@@ -261,10 +256,6 @@ final class TimerRunViewModel {
   /// SwiftData의 StatsModel에 데이터 저장
   @MainActor
   private func save() {
-    guard let timer = timer else {
-      print("세이브 실패. 타이머 데이터가 없습니다.")
-      return
-    }
     do {
       try SwiftDataManager.shared.insertStats(
         icon: timer.iconName, // 타이머 아이콘


### PR DESCRIPTION
## 🔗 관련 이슈

- #161 

## 🔧 PR 요약
- uuid 재조회 대신 TimerModel 직접 주입 방식으로 변경
- 앱 재실행 시 저장된 timerID로 한 번만 모델 조회 후, TimerRunVC로 진입
- viewModel init에서 goalTime 초기화로 순서 변경하여 안정화

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

