### PR TITLE
chore: #165 - 통계 일간/월간 emptyView 텍스트 수정

### DIFF
--- a/PodoIt/Scenes/Stats/ViewComponent/Summary/StatsSummaryView.swift
+++ b/PodoIt/Scenes/Stats/ViewComponent/Summary/StatsSummaryView.swift
@@ -245,26 +245,20 @@ final class StatsSummaryView: UIView {
     collectionView.isHidden = !hasData
     emptyView.isHidden = hasData
 
-    // empty 라벨 텍스트/폰트 토글
+    // empty 라벨 텍스트 토글
     if !hasData {
-      if isDaily {
-        // 일간
-        emptyLabel.attributedText = Typography.attributed(
-          "이 날에는 기록된\n집중 시간이 없어요.",
-          style: .bodyLg(weight: .regular),
-          color: .gray400
-        )
-      } else {
-        // 월간
-        emptyLabel.attributedText = Typography.attributed(
-          "이 달에는 기록된\n집중 시간이 없어요.",
-          style: .bodyLg(weight: .semibold),
-          color: .gray400
-        )
-      }
+      let emptyText = isDaily
+        ? "이 날에는 기록된\n집중 시간이 없어요."
+        : "이 달에는 기록된\n집중 시간이 없어요."
+
+      emptyLabel.attributedText = Typography.attributed(
+        emptyText,
+        style: .bodyLg(weight: .regular),
+        color: .gray400
+      )
     }
     emptyLabel.textAlignment = .center
-    
+
     vStack.spacing = hasData ? Metrics.summaryVStackSpacing : 0
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #165 

## 🔧 PR 요약

- 통계 일간/월간 emptyView 텍스트 두께 수정

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷
https://github.com/user-attachments/assets/0957e371-9f80-45cc-89ed-2bb815631a03