### PR TITLE
refactor: #170 - TimerRunVM에 Dependencies 주입

### DIFF
--- a/PodoIt/Scenes/RootScene/MainTabBarController.swift
+++ b/PodoIt/Scenes/RootScene/MainTabBarController.swift
@@ -30,7 +30,7 @@ final class MainTabBarController: UITabBarController {
     setupAppearance() // 탭바 (컬러/폰트) 설정
     setupViewControllers() // 탭별 화면 연결
   }
-  
+
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     guard let id = initialTimerID else { return }
@@ -41,7 +41,7 @@ final class MainTabBarController: UITabBarController {
         self.initialTimerID = nil
         return
       }
-      let timerRunVC = TimerRunViewController(timer: timer, repo: repository)
+      let timerRunVC = TimerRunViewController(timer: timer)
       timerRunVC.hidesBottomBarWhenPushed = true
       nav.pushViewController(timerRunVC, animated: false)
       self.initialTimerID = nil // 매번 저 화면으로 push할게 아니기에 1번만 하고 nil

--- a/PodoIt/Scenes/Timer/View/TimerViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerViewController.swift
@@ -424,7 +424,7 @@ extension TimerViewController: UICollectionViewDataSource {
       guard let self = self else { return }
       let timer = self.timers[indexPath.item]
       // 타이머 실행 화면으로 이동
-      let runVC = TimerRunViewController(timer: timer, repo: self.repository) // timer 전달
+      let runVC = TimerRunViewController(timer: timer) // timer 전달
       runVC.hidesBottomBarWhenPushed = true // 탭바 숨기기
       self.navigationController?.pushViewController(runVC, animated: true)
     }

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -19,8 +19,8 @@ final class TimerRunViewController: UIViewController {
 
   // MARK: - init
 
-  init(timer: TimerModel, repo: TimerRepository) {
-    self.viewModel = TimerRunViewModel(timer: timer, repo: repo)
+  init(timer: TimerModel) {
+    self.viewModel = TimerRunViewModel(timer: timer)
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by 서광용 on 8/28/25.
 //
 
+import Dependencies
 import Foundation
 import RxCocoa
 import RxSwift
@@ -26,8 +27,7 @@ enum RestAddCase {
 final class TimerRunViewModel {
   // MARK: - Dependencies
 
-//  private let timerID: UUID
-  private let repo: TimerRepository
+  @Dependency(\.timerRepository) private var repo
   private static let udSnapshotKey = "timer_key"
   
   // MARK: - State
@@ -35,7 +35,6 @@ final class TimerRunViewModel {
   private(set) var timer: TimerModel
   private let disposeBag = DisposeBag()
   
-  // FIXME: 사용하지 않을 것 같은 값들 주석. 끝내고도 사용 안하면 삭제 예정
   private(set) var state = TimerSessionState(
     intervalStart: Date(),
     isStudying: true,
@@ -90,9 +89,8 @@ final class TimerRunViewModel {
   
   // MARK: - init
 
-  init(timer: TimerModel, repo: TimerRepository) {
+  init(timer: TimerModel) {
     self.timer = timer
-    self.repo = repo
     goalTime = timer.goalTime * 60 // Int값을 초 단위로 변경
   }
   


### PR DESCRIPTION
## 🔗 관련 이슈

- #170 

## 🔧 PR 요약
- ViewModel에서 @Dependency(\.timerRepository) 사용해 repo 생성자 주입 제거
- VM 전달 뷰에서 repo 파라미터 삭제, VM만 환경에서 참조
- 화면 입력 데이터(TimerModel)는 init(timer:)로 유지

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

