### PR TITLE
chore: #186 - 키보드 위에 저장하기 버튼 뜨도록 수정

### DIFF
--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -39,7 +39,7 @@ final class TimerEditViewController: UIViewController {
     static let textFieldHeight: CGFloat = 56
     static let textFieldLeftPadding: CGFloat = 16
     static let topOffset: CGFloat = 32
-    static let bottomSafeAreaInset: CGFloat = 20
+    static let bottomSafeAreaInset: CGFloat = 16
     static let dashedCircleSize: CGFloat = 40
 
     // Picker
@@ -439,7 +439,7 @@ final class TimerEditViewController: UIViewController {
     saveButton.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview().inset(Metrics.horizontalPadding)
       $0.height.equalTo(Metrics.buttonHeight)
-      $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(Metrics.bottomSafeAreaInset)
+      $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top).offset(-Metrics.bottomSafeAreaInset)
     }
 
     emojiInputField.snp.makeConstraints {

--- a/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
+++ b/PodoIt/Scenes/Timer/View/TimerEditViewController.swift
@@ -249,6 +249,12 @@ final class TimerEditViewController: UIViewController {
     // 이름 필드 변경 실시간 감지 → 비면 빨간 스트로크
     nameTextField.addTarget(self, action: #selector(nameEditingChanged), for: .editingChanged)
 
+    // 키보드 위 미리보기 바 제거
+    for item in [nameTextField, emojiInputField] {
+      item.autocorrectionType = .no
+      item.spellCheckingType = .no
+    }
+
     goalTitleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
     goalTitleLabel.setContentHuggingPriority(.required, for: .vertical)
     goalValueArea.setContentCompressionResistancePriority(.defaultLow, for: .vertical)


### PR DESCRIPTION
## 🔗 관련 이슈

- #186 

## 🔧 PR 요약

- 키보드 위에 저장하기 버튼 뜨도록 수정
- 키보드 위 미리보기? 회색 바 제거

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
<img width="300" height="700" alt="simulator_screenshot_F45E73F1-35EE-422F-A1A1-36462AEAE775" src="https://github.com/user-attachments/assets/a77aeffb-38b4-4981-a5a0-fd556534c736" />|<img width="300" height="700" alt="simulator_screenshot_2DD20BE6-1598-422B-B301-A6D03CD818C8" src="https://github.com/user-attachments/assets/04dc5935-77a3-4365-aab4-a48d21baa171" />
--|--|

## 📎 기타 참고사항
이모지 키보드랑 제목 텍스트 키보드 길이가 안 맞아요ㅜㅜ 이모지 검색 부분 뭔가 지우면 안 될 거 같아서 냅두긴 했는데 그냥 저렇게 할까요?