### PR TITLE
chore: #190 - 노란색 경고(warning) 해결

### DIFF
--- a/PodoIt/DesignSystem/Font/PodoItFontStyle.swift
+++ b/PodoIt/DesignSystem/Font/PodoItFontStyle.swift
@@ -111,8 +111,8 @@ extension UIFont {
   func monospacedDigits() -> UIFont {
     let features: [[UIFontDescriptor.FeatureKey: Any]] = [
       [
-        .featureIdentifier: kNumberSpacingType, // 숫자 간격 기능 그룹
-        .typeIdentifier: kMonospacedNumbersSelector // 위 간격을 고정폭으로 선택
+        .type: kNumberSpacingType, // 어떤 기능 그룹인지: 숫자 간격 기능 그룹
+        .selector: kMonospacedNumbersSelector // 그 그룹 안에서 어떤 옵션을 쓸 것인가: 위 간격을 고정폭으로 선택
       ]
     ]
     let desc = fontDescriptor.addingAttributes([.featureSettings: features]) // 기존 폰트 기반에 만들어둔 features 적용

--- a/PodoIt/Scenes/Setting/View/ThemeSheet/ThemeSheetViewController.swift
+++ b/PodoIt/Scenes/Setting/View/ThemeSheet/ThemeSheetViewController.swift
@@ -52,19 +52,30 @@ final class ThemeSheetViewController: UIViewController {
     $0.rowHeight = UITableView.automaticDimension
     $0.estimatedRowHeight = Layout.rowHeight
   }
+  
+  private lazy var saveButton = UIButton(configuration: {
+    var config = UIButton.Configuration.filled()
+    config.title = "저장하기"
+    config.baseBackgroundColor = .primary600
+    config.baseForegroundColor = .appWhite
+    config.contentInsets = NSDirectionalEdgeInsets(
+            top: Layout.buttonContentV,
+            leading: Layout.buttonContentH,
+            bottom: Layout.buttonContentV,
+            trailing: Layout.buttonContentH
+      )
+    // 모서리
+    config.cornerStyle = .fixed // 아래에서 준 값으로 고정값
+    config.background.cornerRadius = Layout.buttonCornerRadius
 
-  private lazy var saveButton = UIButton(type: .system).then {
-    $0.setTitle("저장하기", for: .normal)
-    $0.setTitleColor(.appWhite, for: .normal)
-    $0.titleLabel?.font = Typography.font(for: .labelLg(weight: .semibold))
-    $0.backgroundColor = .primary600
-    $0.layer.cornerRadius = 12
-    $0.contentEdgeInsets = UIEdgeInsets(
-      top: Layout.buttonContentV,
-      left: Layout.buttonContentH,
-      bottom: Layout.buttonContentV,
-      right: Layout.buttonContentH
-    ) // 버튼 내부와 경계 사이 여백
+    // 폰트
+    config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { font in
+      var out = font
+      out.font = Typography.font(for: .labelLg(weight: .semibold))
+      return out
+    }
+    return config
+  }()).then {
     $0.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
   }
 

--- a/PodoIt/Scenes/TimerRun/View/Sections/ProgressRestSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/ProgressRestSectionView.swift
@@ -40,7 +40,7 @@ final class ProgressRestSectionView: UIView {
   private let buttonsHStackView = UIStackView().then { // 3개 버튼의 H스택뷰
     $0.axis = .horizontal
     $0.alignment = .center
-    $0.distribution = .equalSpacing
+    $0.distribution = .fillEqually
     $0.spacing = 8
   }
 
@@ -126,9 +126,9 @@ final class ProgressRestSectionView: UIView {
       $0.centerX.equalToSuperview()
       $0.top.bottom.equalToSuperview()
     }
-
-    for restAddButton in restAddButtons {
-      restAddButton.snp.makeConstraints {
+    
+    restAddButtons.forEach {
+      $0.snp.makeConstraints {
         $0.width.equalTo(72)
         $0.height.equalTo(44)
       }


### PR DESCRIPTION
## 🔗 관련 이슈

- #190 

## 🔧 PR 요약
- featureIdentifier/typeIdentifier 대신 type/selector 으로 최신 API 사용
- UIButton.Configuration의 contentInsets로 교체


## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?
