### PR TITLE
feat: #196 - 1분 기준으로 Alert 분기

### DIFF
--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -108,9 +108,12 @@ final class TimerRunViewController: UIViewController {
 
     // stop 버튼 tap하여 중지
     buttonSectionView.stopButtonTap
-      .asSignal()
-      .emit(with: self) { vc, _ in
-        PodoAlertController.presentStopTimerAlert(from: vc, onConfirm: {
+      .asDriver()
+      .withLatestFrom(viewModel.isOverOneMinute)
+      .drive(with: self) { vc, isOver in
+        let type: PodoAlertController.StopAlertType = isOver ? .over1Min : .under1Min
+        PodoAlertController
+          .presentStopTimerAlert(from: vc, title: type.title, onConfirm: {
           vc.viewModel.stop()
           vc.navigationController?.popViewController(animated: true)
         })

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -41,7 +41,7 @@ final class TimerRunViewModel {
     totalStudySeconds: 0,
   )
   
-  // isRunningRelay가 값이 바뀔 때마다 이벤트 방출
+  // isStudyingRelay가 값이 바뀔 때마다 이벤트 방출
   private let isStudyingRelay = BehaviorRelay<Bool>(value: true) // accept로 변경 가능하니 노출 x
   var isStudyingDriver: Driver<Bool> { // UI 바인딩용. 호출때마다 Relay를 Driver로 감싼 스트림 반환
     isStudyingRelay.asDriver()
@@ -86,6 +86,7 @@ final class TimerRunViewModel {
   lazy var restingTimeText: Driver<String> = makeRestingTimeText(tigger: restTimeUpdateTrigger) // "남은 휴식시간" 방출 (기본 5분. MM:SS)
 
   lazy var progress: Driver<Float> = makeProgress(tick: tick) // progress 진행률 방출
+  lazy var isOverOneMinute: Driver<Bool> = makeIsOverOneMinute(tick: tick) // 1분 이상인지 아닌지에 따른 Bool값
   
   // MARK: - init
 
@@ -272,7 +273,17 @@ final class TimerRunViewModel {
   }
 
   // MARK: Stream
-
+  
+  private func makeIsOverOneMinute(tick: Observable<Int>) -> Driver<Bool> {
+    return tick.withUnretained(self)
+      .map { vm, _ in
+        let totalStudyTime = vm.totalStudyTime()
+        return totalStudyTime >= 60
+      }
+      .distinctUntilChanged() // 이전값과 새 값이 같으면 방출안하고 무시
+      .asDriver(onErrorJustReturn: false)
+  }
+  
   /// 목표시간 스트림
   private func makeGoalTimeText(tick: Observable<Int>) -> Driver<String> {
     return tick.withUnretained(self)
@@ -281,7 +292,7 @@ final class TimerRunViewModel {
         let remainingStudyTime = max(vm.goalTime - totalStudyTime, 0) // 남은 시간은 목표시간 - 총 공부시간
         return TimerRunViewModel.formatMMSS(seconds: remainingStudyTime)
       }
-      .distinctUntilChanged() // 이전값과 새 값이 같으면 방출안하고 무시
+      .distinctUntilChanged()
       .asDriver(onErrorJustReturn: "00:00")
   }
   

--- a/PodoIt/Support/UI/PodoAlertController.swift
+++ b/PodoIt/Support/UI/PodoAlertController.swift
@@ -20,6 +20,23 @@ final class PodoAlertController: UIViewController {
     static let buttonSpacing: CGFloat = 8
     static let buttonHeight: CGFloat = 48
   }
+  
+  enum StopAlertType {
+    case under1Min
+    case over1Min
+    
+    var title: String {
+      switch self {
+      case .under1Min:
+        return """
+          아직 목표 시간을 채우지 않았어요.
+          그래도 종료할까요?
+          """
+      case .over1Min:
+        return "현재 집중 세션을 종료하시겠습니까?"
+      }
+    }
+  }
 
   // MARK: - API
 
@@ -46,7 +63,7 @@ final class PodoAlertController: UIViewController {
 
   static func presentStopTimerAlert(
     from presenter: UIViewController,
-    title: String = "현재 집중 세션을 종료하시겠습니까?",
+    title: String,
     message: String = "1분 이상 집중한 시간은 그대로 기록돼요.",
     cancelTitle: String = "계속하기",
     confirmTitle: String = "종료하기",


### PR DESCRIPTION


## 🔗 관련 이슈

- #196 

## 🔧 PR 요약
- presentStopTimerAlert의 title을 파라미터로 입력받도록 수정
- StopAlertType에 1분 미만, 이상으로 2가지의 String을 세팅
- 새로운 makeIsOverOneMinute스트림을 만들어서 공부시간 60초 이상인지를 기준으로 Bool값 반환
- VC에서 isOverOneMinute을 같이 구독하여 stop버튼 탭 순간에 Bool값을 통해 Alert title값 변경

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/73e73252-515f-48d6-af20-117bb9ef8078" width="300" />

