### PR TITLE
fix: #229 - 휴식시간이 끝난 이후 추가된 시간 초기화 버그 해결

### DIFF
--- a/PodoIt.xcodeproj/project.pbxproj
+++ b/PodoIt.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = NCUV99Q4S8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PodoIt/Resources/Info.plist;
@@ -207,7 +207,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.PodoIt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -226,7 +226,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = NCUV99Q4S8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PodoIt/Resources/Info.plist;
@@ -244,7 +244,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.PodoIt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -196,7 +196,7 @@ final class TimerRunViewModel {
     // 모든 계산을 restIntervalTime을 기준으로 해서 tick을 다 공통되게 흐르게함
     let restIntervalTime = state.isStudying ? 0 : now.timeIntervalSince(state.intervalStart)
     
-    if zeroMark == true { // 이미 0에 도달했다면
+    if zeroMark == true, addedMark == nil { // 이미 0에 도달했다면
       addedMark = restIntervalTime // 추가를 누른 시점 기준까지 "총 휴식한 시간"을 저장.
     }
     

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -59,8 +59,8 @@ final class TimerRunViewModel {
   
   // 휴식 시간 계산을 위한 변수
   private var zeroMark: Bool = false // 남은 시간이 '처음 0이 된' 순간 (true: 0, false: 0이 되기 전)
-  private var addedMark: Double? // 0상태에서 추가 버튼이 눌린 순간의 restIntervalTime. (새 카운트 다운의 시작점)
-  private var addSnapshot: Double = 0 // 0 도달 당시의 restAddSeconds 스냅샷
+  private var addedMark: Double? // 0상태에서 추가 버튼이 눌린 순간의 restIntervalTime. (버튼을 누른 시점까지의 "총 휴식 경과시간")
+  private var addSnapshot: Double = 0 // 0 도달 당시의 restAddSeconds 스냅샷 (0 도달 전까지 휴식한 시간과 구별하기 위함)
   
   // MARK: - Tick (공유 타이머 스트림)
   
@@ -197,7 +197,7 @@ final class TimerRunViewModel {
     let restIntervalTime = state.isStudying ? 0 : now.timeIntervalSince(state.intervalStart)
     
     if zeroMark == true { // 이미 0에 도달했다면
-      addedMark = restIntervalTime // 추가를 누른 시점의 tick을 저장. 이때부터 카운트다운해서 tick을 맞춤
+      addedMark = restIntervalTime // 추가를 누른 시점 기준까지 "총 휴식한 시간"을 저장.
     }
     
     restUpdateRelay.accept(()) // Void라서 넣지 않고 신호만 보냄. 즉시 갱신
@@ -329,19 +329,20 @@ final class TimerRunViewModel {
 
         if vm.zeroMark == true { // 값이 있으면(이미 0인 상태)
           // 아직 시간이 추가하지 않았다면 "00:00" 유지
-          guard let addedTick = vm.addedMark else {
+          guard let restTimeAtAdd = vm.addedMark else {
             return "00:00"
           }
           
-          // 추가 후 남은 시간 = 추가 버튼을 누른 순간(addedTick)부터 지금까지 흐른 시간
-          // +1분 이라면 1분 안에서 얼마나 지났는지
-          let addRun = max(restIntervalTime - addedTick, 0)
+          /// 휴식시간 추가 후 흐른 시간
+          // 추가 버튼을 누른 순간까지 휴식했던 시간(restTimeAtAdd)부터 지금까지 흐른 시간
+          // 305초에 +1분하고 지금까지 320초가 흘렀다면, 320 - 305 = 15초가 흘렀다는 것
+          let addRun = max(restIntervalTime - restTimeAtAdd, 0)
           
-          // 0이 된 이후 새로 추가된 총 휴식시간만 계산.
+          /// 0이 된 시점 이후 새로 추가된 총 휴식 시간
           // restAddSeconds는 값이 누적되니, 누적된 값이 0으로 다 소진되면, 그 값을 addSnapshot에 넣어서, 추가된 휴식 시간만 쉬도록 보장
           let addSum = max(vm.restAddSeconds - vm.addSnapshot, 0)
           
-          // 화면에 표시할 남은 추가 휴식시간
+          /// 화면에 보여줄 남은 추가 휴식시간
           // 추가된 총 휴식시간(addSum)에서 이미 지난 시간(addRun)을 뺸 값.
           let remaining = max(addSum - addRun, 0)
           


### PR DESCRIPTION
## 🔗 관련 이슈

- #229  

## 🔧 PR 요약
- 휴식시간 추가 로직의 변수명 및 주석 명확화
- 0초 이후 휴식시간 추가 시 남은 시간이 초기화되는 버그 해결

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

- 용량문제로 인해 GIF로 했더니, progressBar등 이상하게 보이는게 있어서, **휴식중인 타이머 부분**만 봐주시면 감사하겠습니다.

<table>
<tr>
<td align="center"><b>시간이 초기화되는 버그 (수정 전)</b></td>
<td align="center"><b>정상 작동되는 모습 (수정 후)</b></td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/cd257670-c7ce-472c-bc33-bbb82c3ee600" width="400"/>
<p align="center">타이머가 0초가 된 후 시간 추가 시,<br>정상적으로 반영되지 않고 초 단위도 초기화되는 문제</p>
</td>
<td>
<img src="https://github.com/user-attachments/assets/1c5deea5-355e-4432-9eb4-880753d4111d" width="400"/>
<p align="center">0초 상태에서도 추가 시간이<br>정상적으로 반영됨 (예: 59초 → 1분 58초)</p>
</td>
</tr>
</table>
