### PR TITLE
fix: #237 - 타이머 실행 시 음소거 버튼 아이콘 버그 해결

### DIFF
--- a/PodoIt/Scenes/TimerRun/View/Sections/HeaderSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/HeaderSectionView.swift
@@ -29,9 +29,7 @@ final class HeaderSectionView: UIView {
     $0.lineBreakMode = .byTruncatingTail // 길면 ...처리
   }
   
-  private let muteButton = UIButton().then {
-    $0.setImage(UIImage(named: "alarm-clock"), for: .normal)
-  }
+  private let muteButton = UIButton()
   
   // MARK: - init
 
@@ -83,6 +81,7 @@ final class HeaderSectionView: UIView {
   }
   
   // MARK: - 음소거 상태에 따라 이미지 교체
+
   func updateMuteIcon(isMute: Bool) {
     muteButton.setImage(UIImage(named: isMute ? "alarm-clock-off" : "alarm-clock"), for: .normal)
   }

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -153,6 +153,7 @@ final class TimerRunViewController: UIViewController {
       .disposed(by: disposeBag)
 
     viewModel.isMuteDriver // 음소거(mute)의 Bool 상태
+      .distinctUntilChanged()
       .drive(with: self) { vc, isMute in
         // 아이콘 초기값 바로 반영
         vc.headerSectionView.updateMuteIcon(isMute: isMute)
@@ -161,6 +162,7 @@ final class TimerRunViewController: UIViewController {
 
     viewModel.isMuteDriver
       .skip(1) // 토스트 알럿은 초기값 무시
+      .distinctUntilChanged()
       .drive(with: self) { vc, isMute in
         vc.showToastBelow(
           isMute ? "알림이 꺼졌어요." : "알림이 켜졌어요.",

--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -77,7 +77,7 @@ final class TimerRunViewController: UIViewController {
     rootStack.snp.makeConstraints {
       $0.directionalEdges.equalTo(view.safeAreaLayoutGuide)
     }
-    
+
     buttonSectionView.snp.makeConstraints {
       $0.height.equalTo(100)
     }
@@ -119,9 +119,9 @@ final class TimerRunViewController: UIViewController {
         let type: PodoAlertController.StopAlertType = isOver ? .over1Min : .under1Min
         PodoAlertController
           .presentStopTimerAlert(from: vc, title: type.title, onConfirm: {
-          vc.viewModel.stop()
-          vc.navigationController?.popViewController(animated: true)
-        })
+            vc.viewModel.stop()
+            vc.navigationController?.popViewController(animated: true)
+          })
       }
       .disposed(by: disposeBag)
 
@@ -152,10 +152,16 @@ final class TimerRunViewController: UIViewController {
       }
       .disposed(by: disposeBag)
 
-    viewModel.isMuteDriver // 음소거(mute)의 Bool 상태 (아래는 tick 모음이라 계속 호출되서 분리)
-      .skip(1)
+    viewModel.isMuteDriver // 음소거(mute)의 Bool 상태
       .drive(with: self) { vc, isMute in
+        // 아이콘 초기값 바로 반영
         vc.headerSectionView.updateMuteIcon(isMute: isMute)
+      }
+      .disposed(by: disposeBag)
+
+    viewModel.isMuteDriver
+      .skip(1) // 토스트 알럿은 초기값 무시
+      .drive(with: self) { vc, isMute in
         vc.showToastBelow(
           isMute ? "알림이 꺼졌어요." : "알림이 켜졌어요.",
           icon: UIImage(named: isMute ? "circle-bang" : "circle-check-green"),


### PR DESCRIPTION
## 🔗 관련 이슈

- #237 

## 🔧 PR 요약
- `HeaderSectionView`에서 `muteButton` 초기 이미지 지정 제거
- `isMuteDriver` 바인딩 분리(아이콘은 초기값 반영, 토스트는 초기값 무시)
- `skip(1)`로 인해 음소거 아이콘 초기 누락되던 문제 수정
- `.distinctUntilChanged()`을 사용하여 같은 값이 방출될 때 불필요한 업데이트 방지

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📎 기타 참고사항
- 영상으로 올리려했지만 용량 문제와 GIF로하면 깨짐이 심해서 이미지 캡처를 함께 올려둔 트러블 슈팅 공유합니다.
  - [[Podoit] 타이머 실행 시 음소거 버튼 아이콘 버그 해결](https://iris-ceres-022.notion.site/Podoit-29c8f738d002801cbadbddfe6d8fdfd6?source=copy_link)
