### PR TITLE
fix: #244 - iOS 26 버전에서 Radius값이 적용되지 않는 문제 해결 및 1.1.2(14) 버전 업데이트

### DIFF
--- a/PodoIt.xcodeproj/project.pbxproj
+++ b/PodoIt.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = NCUV99Q4S8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PodoIt/Resources/Info.plist;
@@ -207,7 +207,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.PodoIt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -226,7 +226,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = NCUV99Q4S8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PodoIt/Resources/Info.plist;
@@ -244,7 +244,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.PodoIt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/PodoIt/Scenes/TimerRun/View/Sections/ButtonSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/ButtonSectionView.swift
@@ -33,7 +33,7 @@ final class ButtonSectionView: UIView {
       bottom: 16,
       trailing: 20
     )
-    config.cornerStyle = .fixed
+    config.cornerStyle = .capsule
     return config
   }())
   
@@ -52,7 +52,7 @@ final class ButtonSectionView: UIView {
       bottom: 16,
       trailing: 20
     )
-    config.cornerStyle = .fixed
+    config.cornerStyle = .capsule
     return config
   }())
   
@@ -67,13 +67,6 @@ final class ButtonSectionView: UIView {
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-  
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    layoutIfNeeded()
-    stopButton.configuration?.background.cornerRadius = stopButton.bounds.height / 2
-    startPauseButton.configuration?.background.cornerRadius = startPauseButton.bounds.height / 2
   }
   
   // MARK: - configureUI

--- a/PodoIt/Scenes/TimerRun/View/Sections/TimerSectionView.swift
+++ b/PodoIt/Scenes/TimerRun/View/Sections/TimerSectionView.swift
@@ -18,8 +18,9 @@ final class TimerSectionView: UIView {
     $0.spacing = 8
   }
 
-  private(set) var statusContainerView = UIView().then { // 아이콘 + 목표 시간/달성 Label
+  private(set) var statusContainerView = CapsuleBackgroundView().then { // 아이콘 + 목표 시간/달성 Label
     $0.backgroundColor = .gray100
+    $0.clipsToBounds = true
   }
 
   private var statusIconImageView = UIImageView().then { // 아이콘
@@ -52,14 +53,6 @@ final class TimerSectionView: UIView {
     super.init(frame: frame)
     configureUI()
     configureLayout()
-  }
-
-  // MARK: - layoutSubviews
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    layoutIfNeeded()
-    statusContainerView.layer.cornerRadius = statusContainerView.bounds.height / 2
   }
 
   @available(*, unavailable)
@@ -145,5 +138,16 @@ final class TimerSectionView: UIView {
       statusIconImageView.tintColor = .green600
       statusTimeLabel.textColor = .green600
     }
+  }
+}
+
+/// 원형 캡슐모양 유지를 위해 CornerRadius를 높이 기반으로 계산
+/// - 상위 뷰의 layoutSubviews 시점에 frame.height가 0으로 잡혀서 직각으로 되는 문제가 있었음
+/// - 그래서 자체 layoutSubviews에서 frame값이 잡힌 후 cornerRadius를 설정하기 위함.
+/// (iOS 18에서는 우연히 타이밍이 맞았지만, iOS 26에서는 깨져서 별도 서브클래스로 분리)
+final class CapsuleBackgroundView: UIView {
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    layer.cornerRadius = bounds.height / 2
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #244 

## 🔧 PR 요약
- TimerSectionView: 상위 뷰 layoutSubviews 제거, 캡슐 전용 서브클래스에서 radius 계산하도록 변경
- ButtonSectionView: 별도 layoutSubviews 없이 configuration.cornerStyle(.capsule) 적용
- 버전을 1.1.2(14)로 업데이트

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

### iOS 26 cornerRadius 이슈 전/후 비교

| 상태 | 집중 상태 | 휴식 상태 |
| --- | --- | --- |
| **수정 전** | <img src="https://github.com/user-attachments/assets/8083dc52-818f-471f-b771-29e5332d68ac" width="300" /> | <img src="https://github.com/user-attachments/assets/e1478aef-68af-46ab-8de9-b1db3eef960f" width="300" /> |
| **수정 후** | <img src="https://github.com/user-attachments/assets/d4ddd550-9b18-4a75-be43-730f0517e45e" width="300" /> | <img src="https://github.com/user-attachments/assets/2d17d920-7db6-45fe-82d7-d472a3fadb90" width="300" /> |

## 📎 기타 참고사항
- iOS 26대응을 위해 xcode 26버전으로 작업했습니다.
- TimerSectionView의 서브클래스를 한 이유는 주석으로 작성해두었으니 참고해주시면 감사하겠습니다.
- [트러블 슈팅 기록 주소](https://iris-ceres-022.notion.site/Podoit-iOS-18-26-cornerRadius-2ab8f738d0028075a4affc4761795a90?source=copy_link)
