### PR TITLE
refactor: #249 - 설정화면 버전/빌드 번호 동적 표시 및 간단한 주석 수정

### DIFF
--- a/PodoIt/Scenes/Setting/Model/SettingModel.swift
+++ b/PodoIt/Scenes/Setting/Model/SettingModel.swift
@@ -22,14 +22,14 @@ enum Theme: String, CaseIterable {
 enum SettingItem {
   case notification(isOn: Bool) // 알림 설정
   case theme(current: Theme) // 테마 변경
-  case inquiry // 문의/건의하기
+  case feedback // 문의/건의하기
   case review // 리뷰 남기기
   
   var title: String {
     switch self {
     case .notification: return "타이머 알림 소리"
     case .theme: return "테마 설정"
-    case .inquiry: return "문의·건의하기"
+    case .feedback: return "문의·건의하기"
     case .review: return "리뷰 남기기"
     }
   }
@@ -44,7 +44,7 @@ enum SettingItem {
     switch self {
     case .notification(let isOn): return .toggle(isOn: isOn)
     case .theme(let current): return .value(text: current)
-    case .inquiry, .review: return .disclosure
+    case .feedback, .review: return .disclosure
     }
   }
 }

--- a/PodoIt/Scenes/Setting/View/Setting/SettingFooterView.swift
+++ b/PodoIt/Scenes/Setting/View/Setting/SettingFooterView.swift
@@ -14,16 +14,13 @@ final class SettingFooterView: UIView {
     static let verticalPadding: CGFloat = 16
   }
 
-  private let versionLabel = UILabel.makeAttributed(
-    text: "ver.1.0.0",
-    style: .captionLg(weight: .regular),
-    color: .gray400
-  )
+  private let versionLabel = UILabel()
 
   override init(frame: CGRect) {
     super.init(frame: frame)
     configureUI()
     configureLayout()
+    appVersion()
   }
 
   @available(*, unavailable)
@@ -40,5 +37,26 @@ final class SettingFooterView: UIView {
       $0.top.bottom.equalToSuperview().inset(Layout.verticalPadding)
       $0.leading.trailing.equalToSuperview().inset(Layout.horizontalPadding)
     }
+  }
+
+  // MARK: - appVersion
+
+  private func appVersion() {
+    guard
+      let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+      let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    else { return }
+
+    #if DEBUG
+      let text = "v\(version) (\(build))"
+    #else
+      let text = "v\(version)"
+    #endif
+
+    versionLabel.attributedText = Typography.attributed(
+      text,
+      style: .captionLg(weight: .regular),
+      color: .gray400
+    )
   }
 }

--- a/PodoIt/Scenes/Setting/View/Setting/SettingViewCell.swift
+++ b/PodoIt/Scenes/Setting/View/Setting/SettingViewCell.swift
@@ -39,8 +39,8 @@ final class SettingViewCell: UITableViewCell {
   
   func configure(_ item: SettingItem) {
     itemLabel.attributedText = Typography.attributed(item.title, style: .headingSm, color: .gray800)
-    // 셀은 재사용되니 문제 생기지 않도록 초기화
     selectionStyle = .none // 셀 선택 하이라이트 안보이도록
+    // 셀은 재사용되니 문제 생기지 않도록 초기화
     accessoryType = .none
     accessoryView = nil
     

--- a/PodoIt/Scenes/Setting/View/Setting/SettingViewController.swift
+++ b/PodoIt/Scenes/Setting/View/Setting/SettingViewController.swift
@@ -151,13 +151,13 @@ extension SettingViewController: UITableViewDataSource {
 
     switch item {
     case .notification:
-      cell.toggleSwitch.rx.isOn // ControlProperty<Bool> 타입
-        // 위의 타입이 ControlProperty<Bool>이면, configure에서 isOn = isOn으로 초기값을 세팅해도 이벤트가 들어감
-        // 그걸 방지하기 위해 .changed를 사용해서 ControlEvent<Bool> 타입으로 변경
-        // 사용자가 직접 토글을 켜거나 끌 때만 값이 방출됨.
+      cell.toggleSwitch.rx.isOn // ControlProperty<Bool> 타입: 값 + 변경 이벤트를 모두 가짐
+        // 코드로 isOn을 세팅할 떄 발생하는 이벤트는 무시하고,
+        // 사용자가 직접 토글한 경우만 받고 싶어서 .changed로 "값이 실제로 변경" 되었을 때만 필터링
+        // ControlProperty<Bool> -> ControlEvent<Bool>로 타입이 변경됨
         .changed
-        // until: cell.rx.meth..여기서 메서드가 1번이라도 호출되면 구독을 자동으로 종료시킴
-        // prepareForReuse가 셀 재사용 직전에 테이블 뷰가 호출
+        // 셀이 재상요되기 직전(prepareForReuse)까지만 이벤트를 받고,
+        // 이후에는 자동으로 구독을 해제해서 중복 바인딩 방지
         // 즉, 이 셀 인스턴스가 재사용 되기 직전까지만 토글 이벤트를 받는다는 의미.
         .take(until: cell.rx.methodInvoked(#selector(UITableViewCell.prepareForReuse)))
         .bind(with: self) { vc, isOn in

--- a/PodoIt/Scenes/Setting/View/Setting/SettingViewController.swift
+++ b/PodoIt/Scenes/Setting/View/Setting/SettingViewController.swift
@@ -118,7 +118,7 @@ extension SettingViewController: UITableViewDelegate {
       }, selectedTheme: current)
       sheetVC.modalPresentationStyle = .pageSheet
       present(sheetVC, animated: true)
-    case .inquiry:
+    case .feedback:
       guard let url = URL(string: "https://docs.google.com/forms/d/e/1FAIpQLSc7ek143AR7jBzxrNdbQsHJso4Nv4n_41v0ExHlXwsOHi6gfQ/viewform?usp=header") else { return }
       let safariViewController = SFSafariViewController(url: url)
       present(safariViewController, animated: true, completion: nil)

--- a/PodoIt/Scenes/Setting/View/Setting/SettingViewController.swift
+++ b/PodoIt/Scenes/Setting/View/Setting/SettingViewController.swift
@@ -13,7 +13,7 @@ import UIKit
 
 final class SettingViewController: UIViewController {
   private let viewModel = SettingViewModel()
-  private let myAppID = 6752013483
+  private let appID = 6752013483
   private let disposeBag = DisposeBag()
 
   private lazy var tableView = UITableView(frame: .zero, style: .plain).then {
@@ -124,8 +124,8 @@ extension SettingViewController: UITableViewDelegate {
       present(safariViewController, animated: true, completion: nil)
     case .review:
       guard
-        let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id\(myAppID)"), // App Store 앱 직행
-        let webURL = URL(string: "https://apps.apple.com/app/id\(self.myAppID)") // 웹으로 이동(Safari 백업용)
+        let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id\(appID)"), // App Store 앱 직행
+        let webURL = URL(string: "https://apps.apple.com/app/id\(self.appID)") // 웹으로 이동(Safari 백업용)
       else { return }
 
       // 먼저 App Store 시도 → 실패하면 Safari로 연결
@@ -156,9 +156,9 @@ extension SettingViewController: UITableViewDataSource {
         // 그걸 방지하기 위해 .changed를 사용해서 ControlEvent<Bool> 타입으로 변경
         // 사용자가 직접 토글을 켜거나 끌 때만 값이 방출됨.
         .changed
-      // until: cell.rx.meth..여기서 메서드가 1번이라도 호출되면 구독을 자동으로 종료시킴
-      // prepareForReuse가 셀 재사용 직전에 테이블 뷰가 호출
-      // 즉, 이 셀 인스턴스가 재사용 되기 직전까지만 토글 이벤트를 받는다는 의미.
+        // until: cell.rx.meth..여기서 메서드가 1번이라도 호출되면 구독을 자동으로 종료시킴
+        // prepareForReuse가 셀 재사용 직전에 테이블 뷰가 호출
+        // 즉, 이 셀 인스턴스가 재사용 되기 직전까지만 토글 이벤트를 받는다는 의미.
         .take(until: cell.rx.methodInvoked(#selector(UITableViewCell.prepareForReuse)))
         .bind(with: self) { vc, isOn in
           vc.viewModel.updateIsMute(isOn: isOn)

--- a/PodoIt/Scenes/Setting/ViewModel/SettingViewModel.swift
+++ b/PodoIt/Scenes/Setting/ViewModel/SettingViewModel.swift
@@ -27,9 +27,9 @@ final class SettingViewModel {
     self.currentTheme = Theme(rawValue: saved ?? "") ?? .system
     
     // AudioSettings의 현재 상태를 초기값으로 반영
-    let initalIsOn = !(audio.isMute.value)
+    let notificationIsOn = !(audio.isMute.value)
     self.items = [
-      .notification(isOn: initalIsOn),
+      .notification(isOn: notificationIsOn),
       // TODO: 테마 셀은 기능 완성 시 다시 노출
       // UserDefaults 저장과 UI는 완성. 어떤 상태를 했냐에 따라서 테마 변경만 지원하면 끝.
       // .theme(current: currentTheme),

--- a/PodoIt/Scenes/Setting/ViewModel/SettingViewModel.swift
+++ b/PodoIt/Scenes/Setting/ViewModel/SettingViewModel.swift
@@ -33,7 +33,7 @@ final class SettingViewModel {
       // TODO: 테마 셀은 기능 완성 시 다시 노출
       // UserDefaults 저장과 UI는 완성. 어떤 상태를 했냐에 따라서 테마 변경만 지원하면 끝.
       // .theme(current: currentTheme),
-      .inquiry,
+      .feedback,
       .review
     ]
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- #249 

## 🔧 PR 요약
- 문의/건의하기 변수명 변경
- 주석위치 변경
- `SettingVC` 주석 내용 수정
- 하드코딩값을 제거하고, 설정 화면 앱 버전 표시 값 자동 연동으로 변경
  - `Info.plist`의 `Version`, `Build` 값을 `Bundle`로 동적 조회
  - `DEBUG` 환경에서만 빌드 번호를 표시하도록 분기 처리

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📎 기타 참고사항

- 참고 자료: [iOS 앱의 버전 관리에 대해(앱 버전 및 빌드 버전)](https://jazz-the-it.tistory.com/52)
- 작성한 TIL: [[Podoit] 앱 버전을 하드코딩 없이 동적으로 표시하기 (Bundle & Info.plist)](https://iris-ceres-022.notion.site/Podoit-Bundle-Info-plist-2bb8f738d00280b291b7fae3caead279?source=copy_link)
