### PR TITLE
refactor: #271 - TimerRunVM 통계 저장 의존성 주입 전환

### DIFF
--- a/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
+++ b/PodoIt/Scenes/TimerRun/View/TimerRunViewController.swift
@@ -20,7 +20,7 @@ final class TimerRunViewController: UIViewController {
   // MARK: - init
 
   init(timer: TimerModel) {
-    self.viewModel = TimerRunViewModel(timer: timer)
+    self.viewModel = TimerRunViewModel(timer: timer, statsRepository: SwiftDataManager.shared)
     super.init(nibName: nil, bundle: nil)
   }
 

--- a/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
+++ b/PodoIt/Scenes/TimerRun/ViewModel/TimerRunViewModel.swift
@@ -38,6 +38,7 @@ final class TimerRunViewModel {
   // MARK: - State
 
   private(set) var timer: TimerModel
+  private let statsRepository: StatsRepository
   private(set) var state = TimerSessionState(
     intervalStart: Date(),
     isStudying: true,
@@ -97,8 +98,9 @@ final class TimerRunViewModel {
   
   // MARK: - init
 
-  init(timer: TimerModel) {
+  init(timer: TimerModel, statsRepository: StatsRepository) {
     self.timer = timer
+    self.statsRepository = statsRepository
     goalTime = Double(timer.goalTime) * 60 // Int값을 초 단위로 변경
   }
   
@@ -194,7 +196,8 @@ final class TimerRunViewModel {
   @MainActor
   private func save() {
     do {
-      try SwiftDataManager.shared.insertStats(
+      try statsRepository.insertStats(
+        date: Date(),
         icon: timer.iconName, // 타이머 아이콘
         category: timer.title, // 타이머 이름
         time: TimerRunViewModel.elapsedFormatHMMSS(seconds: state.totalStudySeconds) // 총 공부 시간


### PR DESCRIPTION

## 🔗 관련 이슈

- #271 

## 🔧 PR 요약
- `TimerRunViewModel`의 통계 저장 로직에서 `SwiftDataManager.shaerd` 직접 호출을 제거
- T`imerRunViewModel`이 `StatsRepository`를 생성자 주입으로 받도록 변경
- `save()`에서 `statsRepository.insertStats(...)` 호출로 전환
- `TimerRunVC`에서 `TimerRunViewModel` 생성 시 `SwiftDataManager.shared`를 주입하도록 함
  - (변경사항) Swift 6 MainActor 격리 경고가 떠서 `init` 기본값 위치를 `TimerRunVC`로 정리하였음.


## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [ ] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?
